### PR TITLE
Allow examination of intermediate wavefront planes when propagating with SAM, multiprocessing, or both

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1182,7 +1182,8 @@ class OpticalSystem(object):
 
         if conf.enable_speed_tests:
             t_start = time.time()
-        if self.verbose: _log.info(" Propagating wavelength = %g meters %s")
+        if self.verbose:
+           _log.info(" Propagating wavelength = {0:g} meters".format(wavelength))
         wavefront = self.inputWavefront(wavelength)
 
         intermediate_wfs = []

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1360,7 +1360,7 @@ class OpticalSystem(object):
                 if outFITS is None:
                     # for the first wavelength processed, set up the arrays where we accumulate the output
                     outFITS = mono_psf
-                    outFITS[0].data = mono_psf[0].data * wave_weight
+                    outFITS[0].data *= wave_weight
                     intermediate_wfs = mono_intermediate_wfs
                     for wavefront in intermediate_wfs:
                         wavefront *= wave_weight  # modifies Wavefront in-place

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1235,7 +1235,7 @@ class OpticalSystem(object):
         return wavefront.asFITS(), intermediate_wfs
 
     def calcPSF(self, wavelength=1e-6, weight=None, save_intermediates=False, save_intermediates_what='all',
-                display=False, return_intermediates=False, source=None, normalize='first'):
+                display=False, return_intermediates=False, source=None, normalize='first', display_intermediates=False):
         """Calculate a PSF, either multi-wavelength or monochromatic.
 
         The wavelength coverage computed will be:
@@ -1260,6 +1260,9 @@ class OpticalSystem(object):
             a dict containing 'wavelengths' and 'weights' list.
         normalize : string, optional
             How to normalize the PSF. See the documentation for propagate_mono() for details.
+        display_intermediates: bool, optional
+            Display intermediate optical planes? Default is False. This option is incompatible with
+            parallel calculations using `multiprocessing`. (If calculating in parallel, it will have no effect.)
 
         Returns
         -------
@@ -1308,7 +1311,6 @@ class OpticalSystem(object):
             if display:
                 _log.warn('Display during calculations is not supported for multiprocessing mode. Please set poppy.conf.use_multiprocessing.set(False) if you want to use display=True.')
                 _log.warn('(Plot the returned PSF with poppy.utils.display_PSF.)')
-                display = False
 
             if save_intermediates:
                 _log.warn('Saving intermediate steps does not take advantage of multiprocess parallelism. '
@@ -1350,7 +1352,7 @@ class OpticalSystem(object):
                 mono_psf, mono_intermediate_wfs = self.propagate_mono(
                     wlen,
                     retain_intermediates=retain_intermediates,
-                    display_intermediates=display,
+                    display_intermediates=display_intermediates,
                     normalize=normalize
                 )
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1313,6 +1313,10 @@ class OpticalSystem(object):
                 _log.warn('Display during calculations is not supported for multiprocessing mode. Please set poppy.conf.use_multiprocessing.set(False) if you want to use display=True.')
                 _log.warn('(Plot the returned PSF with poppy.utils.display_PSF.)')
 
+            if return_intermediates:
+                _log.warn('Memory usage warning: When preserving intermediate optical planes in multiprocessing mode, '
+                          'memory usage scales with the number of planes times the number of wavelengths. Disable '
+                          'use_multiprocessing if you are running out of memory.')
             if save_intermediates:
                 _log.warn('Saving intermediate steps does not take advantage of multiprocess parallelism. '
                           'Set save_intermediates=False for improved speed.')

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -66,13 +66,13 @@ def _wrap_propagate_for_multiprocessing(args):
     as a tuple, transmitting that to the new process, and then unpickling that,
     unpacking the results, and *then* at last making our instance method call.
     """
-    instrument_object, wavelength, weight, kwargs, usefftwflag = args
+    optical_system, wavelength, retain_intermediates, normalize, usefftwflag = args
     conf.use_fftw = usefftwflag  #passed in from parent process
 
-    if conf.use_fftw and _FFTW_AVAILABLE: # we're in a different Python interprepter process so we 
+    if conf.use_fftw and _FFTW_AVAILABLE: # we're in a different Python interpreter process so we
         utils.fftw_load_wisdom()          # need to load the wisdom here too
 
-    return instrument_object.propagate_mono(wavelength, poly_weight=weight, retain_intermediates=False, **kwargs)
+    return optical_system.propagate_mono(wavelength, retain_intermediates=retain_intermediates, normalize=normalize)
 
 
 #------ Wavefront class -----
@@ -1148,9 +1148,11 @@ class OpticalSystem(object):
             _log.debug("Tilted input wavefront by theta_X=%f, theta_Y=%f arcsec" % (offset_x, offset_y))
         return inwave
 
-    def propagate_mono(self, wavelength=2e-6, normalize='first', retain_intermediates=False, display_intermediates=False, poly_weight=None):
-        """ Propagate a monochromatic wavefront through the optical system. Called from within calcPSF.
-        Returns a fits.HDUList object.
+    def propagate_mono(self, wavelength=2e-6, normalize='first',
+                       retain_intermediates=False, display_intermediates=False):
+        """Propagate a monochromatic wavefront through the optical system. Called from within `calcPSF`.
+        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
+        `retain_intermediates=False`).
 
         Parameters
         ----------
@@ -1162,31 +1164,31 @@ class OpticalSystem(object):
             * 'last' = set total flux = 1 after the entire optical system.
             * 'first=2' = set total flux = 2 after the first optic (used for debugging only)
         display_intermediates : bool
-            Should intermediate steps in the calculation be displayed on screen? Default False
-        save_intermediates : bool TODO FIX NAME
-            Should intermediate steps in the calculation be saved to disk? Default False.
-            If this is True, then setting `poly_weight` controls whether intermediate optical planes are actually saved to *disk* by this routine
-            (for the monochromatic case) or are passed back up via memory and handled in `calcPSF` (for the polychromatic case).
-        poly_weight : float
-            is this being called as part of a polychromatic calculation?
-            if not, set this to None. if so, set this to the weight for
-            that wavelength. (This is used only for properly normalizing the
-            multiwavelength FITs file written to disk if save_intermediates is set.)
+            Should intermediate steps in the calculation be displayed on screen? Default: False.
+        retain_intermediates : bool
+            Should intermediate steps in the calculation be retained? Default: False.
+            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
+            representing intermediate optical planes from the calculation.
 
-
+        Returns
+        -------
+        final_wf : fits.HDUList
+            The final result of the monochromatic propagation as a FITS HDUList
+        intermediate_wfs : list
+            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
+            The 0th item is "before first optical plane", 1st is "after first plane and before second plane", and so on.
+            (n.b. This will be empty if `retain_intermediates` is False.)
         """
 
         if conf.enable_speed_tests:
             t_start = time.time()
-        if self.verbose: _log.info(" Propagating wavelength = %g meters %s" % (wavelength, "" if poly_weight is None else " with weight=%.2f" % poly_weight))
+        if self.verbose: _log.info(" Propagating wavelength = %g meters %s")
         wavefront = self.inputWavefront(wavelength)
 
-        if retain_intermediates and poly_weight is None:
-            self.intermediate_wfs = []
-            _log.warning("User requested saving intermediates, but no weight for this wavelength is provided - cannot properly calculate intermediate wavefront")
-            _log.debug("reset intermediates")
+        intermediate_wfs = []
 
-        current_plane_index = 0  # note: 0 is 'before first optical plane; 1 = 'after first plane and before second plane' and so on
+        # note: 0 is 'before first optical plane; 1 = 'after first plane and before second plane' and so on
+        current_plane_index = 0
         for optic in self.planes:
             # The actual propagation:
             wavefront.propagateTo(optic)
@@ -1214,7 +1216,7 @@ class OpticalSystem(object):
             if conf.enable_flux_tests: _log.debug("  Flux === "+str(wavefront.totalIntensity))
 
             if retain_intermediates: # save intermediate wavefront, summed for polychromatic if needed
-                self._storeIntermediate(current_plane_index, wavefront, poly_weight)
+                intermediate_wfs.append(wavefront.copy())
 
             if display_intermediates:
                 if conf.enable_speed_tests: t0 = time.time()
@@ -1230,55 +1232,43 @@ class OpticalSystem(object):
             t_stop = time.time()
             _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop-t_start))
 
-        return wavefront.asFITS()  # this returns the intensity, by default. 
+        return wavefront.asFITS(), intermediate_wfs
 
-    def _storeIntermediate(self, plane_index, wavefront, weight):
-        if weight is None:
-            intermediate_wf = wavefront.copy()
-        else:
-            intermediate_wf = weight * wavefront.copy()
-        if len(self.intermediate_wfs) < current_plane_index:
-            self.intermediate_wfs.append(intermediate_wf)
-        else:
-            self.intermediate_wfs[plane_index - 1] += intermediate_wf
-        _log.info("    Storing intermediate wavefront plane %d with weight %f" % (plane_index - 1, weight))
-
-    def calcPSF(self, wavelength=1e-6, weight=None, display=False, display_intermediates=False,
-        save_intermediates=False, save_intermediates_what='all', return_intermediates=False,
-        source=None, normalize='first'):
+    def calcPSF(self, wavelength=1e-6, weight=None, save_intermediates=False, save_intermediates_what='all',
+                display=False, return_intermediates=False, source=None, normalize='first'):
         """Calculate a PSF, either multi-wavelength or monochromatic.
 
         The wavelength coverage computed will be:
-        - multi-wavelength PSF over some weighted sum of wavelengths (if you provide a source parameter)
-        - monochromatic (if you provide just a wavelen= parameter)
-
-        Any additional `kwargs` will be passed on to `propagate_mono()`
+        - multi-wavelength PSF over some weighted sum of wavelengths (if you provide a `source` argument)
+        - monochromatic (if you provide just a `wavelength` argument)
 
         Parameters
         ----------
-        source : dict
-            a dict containing 'wavelengths' and 'weights' list.
-            *TBD - replace w/ pysynphot observation object*
-        wavelen : float, optional
+        wavelength : float, optional
             wavelength in meters for monochromatic calculation.
-        display_intermediates : bool, optional
-            whether to show the intermediate optical planes. Default is False
+        weight : float, optional
+            weight by which to multiply output plane
         save_intermediates : bool, optional
             whether to output intermediate optical planes to disk. Default is False
         save_intermediate_what : string, optional
             What to save - phase, intensity, amplitude, complex, parts, all. Default is all.
+        display : bool, optional
+            whether to plot the results when finished or not.
         return_intermediates: bool, optional
             return intermediate wavefronts as well as PSF?
-        display : bool, optional
-            whether to display when finished or not.
+        source : dict
+            a dict containing 'wavelengths' and 'weights' list.
         normalize : string, optional
-            How to normalize the PSF. See propagate_mono() for details.
-
+            How to normalize the PSF. See the documentation for propagate_mono() for details.
 
         Returns
         -------
         outfits :
             a fits.HDUList
+        intermediate_wfs : list of `poppy.Wavefront` objects (optional)
+            Only returned if `return_intermediates` is specified.
+            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
+            The 0th item is "before first optical plane", 1st is "after first plane and before second plane", and so on.
         """
 
         tstart = time.time() 
@@ -1294,19 +1284,15 @@ class OpticalSystem(object):
         if len(tuple(wavelength)) != len(tuple(weight)):
             raise ValueError("Input source has different number of weights and wavelengths...")
 
-        if display: plt.clf()
-
-        if save_intermediates or return_intermediates:
-            self.intermediate_wfs = []
-            _log.info("User requested saving intermediate wavefronts in call to poppy.calcPSF")
-            _log.debug('reset intermediates in calcPSF')
-            #raise ValueError("Saving intermediates for multi-wavelen not yet implemented!!")
-        else:
-            self.intermediate_wfs = None
-
         # loop over wavelengths
         if self.verbose: _log.info("Calculating PSF with %d wavelengths" % (len(wavelength)))
         outFITS = None
+        intermediate_wfs = None
+        if save_intermediates or return_intermediates:
+            _log.info("User requested saving intermediate wavefronts in call to poppy.calcPSF")
+            retain_intermediates = True
+        else:
+            retain_intermediates = False
 
         normwts =  np.asarray(weight, dtype=float)
         normwts /= normwts.sum()
@@ -1315,82 +1301,98 @@ class OpticalSystem(object):
         if _USE_FFTW:
             utils.fftw_load_wisdom()
 
-
-        if conf.use_multiprocessing and len(wavelength) > 1 : ######### Parallellized computation ############
+        if conf.use_multiprocessing and len(wavelength) > 1: ######### Parallellized computation ############
             if _USE_FFTW: 
                 _log.warn('IMPORTANT WARNING: Python multiprocessing and fftw3 do not appear to play well together. This may crash intermittently')
                 _log.warn('   We suggest you set   poppy.conf.use_fftw to False   if you want to use multiprocessing().')
             if display:
                 _log.warn('Display during calculations is not supported for multiprocessing mode. Please set poppy.conf.use_multiprocessing.set(False) if you want to use display=True.')
-                _log.warn('For now, display is being set to False.')
-                display=False
+                _log.warn('(Plot the returned PSF with poppy.utils.display_PSF.)')
+                display = False
 
             if save_intermediates:
-                raise NotImplementedError("Can't save intermediate steps if using parallelized code")
+                _log.warn('Saving intermediate steps does not take advantage of multiprocess parallelism. '
+                          'Set save_intermediates=False for improved speed.')
 
             # do *NOT* just blindly try to create as many processes as one has CPUs, or one per wavelength either
             # This is a memory-intensive task so that can end up swapping to disk and thrashing IO
-            nproc = conf.n_processes if conf.n_processes > 1 else utils.estimate_optimal_nprocesses(self, nwavelengths=len(wavelength))
+            nproc = conf.n_processes if conf.n_processes > 1 \
+                                     else utils.estimate_optimal_nprocesses(self, nwavelengths=len(wavelength))
 
-            pool = multiprocessing.Pool( int(nproc) )  # be sure to cast to int, will fail if given a float even if of integer value
-
+            # be sure to cast to int, will fail if given a float even if of integer value
+            pool = multiprocessing.Pool(int(nproc))
 
             # build a single iterable containing the required function arguments
             _log.info("Beginning multiprocessor job using {0} processes".format(nproc))
-            iterable = [(self, wavelen, wt, kwargs, _USE_FFTW) for wavelen, wt in zip(wavelength, normwts)]
-            results = pool.map(_wrap_propagate_for_multiprocessing, iterable)
+            worker_arguments = [(self, wlen, retain_intermediates, normalize, _USE_FFTW)
+                                for wlen in wavelength]
+            results = pool.map(_wrap_propagate_for_multiprocessing, worker_arguments)
             _log.info("Finished multiprocessor job")
             pool.close()
 
             # Sum all the results up into one array, using the weights
-            outFITS = results[0]
+            outFITS, intermediate_wfs = results[0]
             outFITS[0].data *= normwts[0]
             _log.info("got results for wavelength channel %d / %d" % (0, len(tuple(wavelength))) )
             for i in range(1, len(normwts)):
+                mono_psf, mono_intermediate_wfs = results[i]
+                wave_weight = normwts[i]
                 _log.info("got results for wavelength channel %d / %d" % (i, len(tuple(wavelength))) )
-                outFITS[0].data += results[i][0].data * normwts[i]
+                outFITS[0].data += mono_psf[0].data * wave_weight
+                for idx, wavefront in enumerate(mono_intermediate_wfs):
+                    intermediate_wfs[idx] += wavefront * wave_weight
             outFITS[0].header.add_history("Multiwavelength PSF calc on %d processors completed." % conf.n_processes)
 
         else:  ########## single-threaded computations (may still use multi cores if FFTW enabled ######
-            for wavelen, wave_weight in zip(wavelength, normwts):
-            #for wavelen, weight in zip(source['wavelengths'], normwts):
-                mono_psf = self.propagate_mono(wavelen, poly_weight=wave_weight,
-                                               retain_intermediates=save_intermediates or return_intermediates,
-                                               display_intermediates=display_intermediates, normalize=normalize)
-                # add mono_psf into the output array:
+            if display:
+                plt.clf()
+            for wlen, wave_weight in zip(wavelength, normwts):
+                mono_psf, mono_intermediate_wfs = self.propagate_mono(
+                    wlen,
+                    retain_intermediates=retain_intermediates,
+                    display_intermediates=display,
+                    normalize=normalize
+                )
 
                 if outFITS is None:
+                    # for the first wavelength processed, set up the arrays where we accumulate the output
                     outFITS = mono_psf
                     outFITS[0].data = mono_psf[0].data * wave_weight
+                    intermediate_wfs = mono_intermediate_wfs
+                    for wavefront in intermediate_wfs:
+                        wavefront *= wave_weight  # modifies Wavefront in-place
                 else:
+                    # for subsequent wavelengths, scale and add the data to the existing arrays
                     outFITS[0].data += mono_psf[0].data * wave_weight
+                    for idx, wavefront in enumerate(mono_intermediate_wfs):
+                        intermediate_wfs[idx] += wavefront * wave_weight
 
-            if save_intermediates:
-                for i in range(len(self.intermediate_wfs)):
-                    self.intermediate_wfs[i].writeto('wavefront_plane_%03d.fits' % i, what=save_intermediates_what, **kwargs )
+            if display:
+                # Add final intensity panel to intermediate WF plot
+                cmap = matplotlib.cm.jet
+                cmap.set_bad('0.3')
+                #cmap.set_bad('k', 0.8)
+                halffov_x =outFITS[0].header['PIXELSCL']*outFITS[0].data.shape[1]/2
+                halffov_y =outFITS[0].header['PIXELSCL']*outFITS[0].data.shape[0]/2
+                extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
+                unit="arcsec"
+                norm=matplotlib.colors.LogNorm(vmin=1e-8,vmax=1e-1)
+                plt.xlabel(unit)
+
+                utils.imshow_with_mouseover(outFITS[0].data, extent=extent, norm=norm, cmap=cmap)
+
+        if save_intermediates:
+            _log.info('Saving intermediate wavefronts:')
+            for idx, wavefront in enumerate(intermediate_wfs):
+                filename = 'wavefront_plane_%03d.fits' % i
+                wavefront.writeto(filename, what=save_intermediates_what)
+                _log.info('  saved {} to {} ({} / {})'.format(save_intermediates_what, filename,
+                                                              idx, len(intermediate_wfs)))
 
         tstop = time.time()
         tdelta = tstop-tstart
         _log.info("  Calculation completed in {0:.3f} s".format(tdelta))
         outFITS[0].header.add_history("Calculation completed in {0:.3f} seconds".format(tdelta))
-
-
-
-        if display:
-            # This display may be redundant if display_intermediates is not already set...
-            cmap = matplotlib.cm.jet
-            cmap.set_bad('0.3')
-            #cmap.set_bad('k', 0.8)
-            halffov_x =outFITS[0].header['PIXELSCL']*outFITS[0].data.shape[1]/2
-            halffov_y =outFITS[0].header['PIXELSCL']*outFITS[0].data.shape[0]/2
-            extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
-            unit="arcsec"
-            norm=matplotlib.colors.LogNorm(vmin=1e-8,vmax=1e-1)
-            plt.xlabel(unit)
-
-            utils.imshow_with_mouseover(outFITS[0].data, extent=extent, norm=norm, cmap=cmap)
-
-
 
         if _USE_FFTW and conf.autosave_fftw_wisdom:
             utils.fftw_save_wisdom()
@@ -1408,13 +1410,12 @@ class OpticalSystem(object):
         outFITS[0].header['FFTTYPE'] = (ffttype, 'Algorithm for FFTs: numpy or fftw')
         outFITS[0].header['NORMALIZ'] = (normalize, 'PSF normalization method')
 
-
-        if self.verbose: _log.info("PSF Calculation completed.")
+        if self.verbose:
+            _log.info("PSF Calculation completed.")
         if return_intermediates:
-            return outFITS, self.intermediate_wfs
+            return outFITS, intermediate_wfs
         else:
             return outFITS
-
 
     def display(self, **kwargs):
         """ Display all elements in an optical system on screen.
@@ -1522,35 +1523,45 @@ class SemiAnalyticCoronagraph(OpticalSystem):
 
         self.occulter_det = Detector(self.detector.pixelscale/self.oversample, fov_arcsec = self.occulter_box*2, name='Oversampled Occulter Plane')
 
-    def propagate_mono(self, wavelength=2e-6, normalize='first', poly_weight=None,
+    def propagate_mono(self, wavelength=2e-6, normalize='first',
                        retain_intermediates=False, display_intermediates=False):
-        """
+        """Propagate a monochromatic wavefront through the optical system. Called from within `calcPSF`.
+        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
+        `retain_intermediates=False`).
 
         Parameters
-        -------------
+        ----------
         wavelength : float
             Wavelength in meters
         normalize : string, {'first', 'last'}
             how to normalize the wavefront?
+            * 'first' = set total flux = 1 after the first optic, presumably a pupil
+            * 'last' = set total flux = 1 after the entire optical system.
+        display_intermediates : bool
+            Should intermediate steps in the calculation be displayed on screen? Default: False.
+        retain_intermediates : bool
+            Should intermediate steps in the calculation be retained? Default: False.
+            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
+            representing intermediate optical planes from the calculation.
 
-            * 'first' : set total flux = 1 after the first optic, presumably a pupil
-            * 'last' : set total flux = 1 after the entire optical system.
-
-
-        save_intermediates, display_intermediates, intermediate_fn, poly_weight : bools
-            TODO document like OpticalSystem.propagate_mono
-
+        Returns
+        -------
+        final_wf : fits.HDUList
+            The final result of the monochromatic propagation as a FITS HDUList
+        intermediate_wfs : list
+            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
+            The 0th item is "before first optical plane", 1st is "after first plane and before second plane", and so on.
+            (n.b. This will be empty if `retain_intermediates` is False.)
         """
-        if conf.enable_speed_tests: t_start = time.time()
-        if self.verbose: _log.info(" Propagating wavelength = {0:g} meters {1}, using Fast Semi-Analytic Coronagraph method".format(wavelength, "" if poly_weight is None else " with weight=%.2f" % poly_weight))
+        if conf.enable_speed_tests:
+           t_start = time.time()
+        if self.verbose:
+           _log.info(" Propagating wavelength = {0:g} meters using "
+                     "Fast Semi-Analytic Coronagraph method".format(wavelength))
         wavefront = self.inputWavefront(wavelength)
         current_plane_index = 0
 
-        if retain_intermediates and poly_weight is None:
-            self.intermediate_wfs = []
-            _log.warning("User requested retaining intermediates, but no weight for this wavelength is provided - "
-                         "cannot properly calculate intermediate wavefront")
-            _log.debug("reset intermediates")
+        intermediate_wfs = []
 
         #------- differences from regular propagation begin here --------------
         wavefront *= self.inputpupil
@@ -1559,7 +1570,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         if normalize.lower() == 'first':
             wavefront.normalize()
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront, poly_weight)
+            intermediate_wfs.append(wavefront.copy())
 
         if display_intermediates:
             nrows = 6
@@ -1573,7 +1584,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         wavefront_cor.propagateTo(self.occulter_det)
         current_plane_index += 1
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront_cor, poly_weight)
+            intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:
             wavefront_cor.display(what='best',nrows=nrows,row=2, colorbar=False)
@@ -1582,7 +1593,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         wavefront_cor *= self.mask_function
         current_plane_index += 1
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront_cor, poly_weight)
+            intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:
             wavefront_cor.display(what='best',nrows=nrows,row=3, colorbar=False)
@@ -1593,7 +1604,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         wavefront_lyot.propagateTo(self.lyotplane)
         current_plane_index += 1
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront_lyot, poly_weight)
+            intermediate_wfs.append(wavefront_lyot.copy())
 
         if display_intermediates:
             wavefront_lyot.display(what='best',nrows=nrows,row=4, colorbar=False)
@@ -1604,7 +1615,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         wavefront_combined.location = 'after combined Lyot pupil'
         current_plane_index += 1
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront_combined, poly_weight)
+            intermediate_wfs.append(wavefront_combined.copy())
 
         if display_intermediates:
             wavefront_combined.display(what='best',nrows=nrows,row=5, colorbar=False)
@@ -1613,7 +1624,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
         wavefront_combined.propagateTo(self.detector)
         current_plane_index += 1
         if retain_intermediates:
-            self._storeIntermediate(current_plane_index, wavefront_combined, poly_weight)
+            intermediate_wfs.append(wavefront_combined.copy())
 
         if display_intermediates: 
             wavefront_combined.display(what='best',nrows=nrows,row=6, colorbar=False)
@@ -1630,7 +1641,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
             t_stop = time.time()
             _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop-t_start))
 
-        return wavefront_combined.asFITS()
+        return wavefront_combined.asFITS(), intermediate_wfs
 
 
 #------ core Optical Element Classes ------

--- a/poppy/tests/test_fft.py
+++ b/poppy/tests/test_fft.py
@@ -90,19 +90,16 @@ def test_fft_fqpm(): #oversample=2, verbose=True, wavelength=2e-6):
 
     oversamp=2
     osys = poppy_core.OpticalSystem("test", oversample=oversamp)
-    osys.addPupil( optics.CircularAperture(radius=radius)   )
-    osys.addPupil( optics.FQPM_FFT_aligner()  ) #'FQPM_FFT_aligner')
-    osys.addImage( optics.IdealFQPM( wavelength=wavelen) )  # perfect FQPM for this wavelength
-    osys.addImage( optics.RectangularFieldStop( width=6.0))
-    osys.addPupil( optics.FQPM_FFT_aligner(direction='backward'))
-    osys.addPupil( optics.CircularAperture(radius=radius))
+    osys.addPupil(optics.CircularAperture(radius=radius))
+    osys.addPupil(optics.FQPM_FFT_aligner())
+    osys.addImage(optics.IdealFQPM(wavelength=wavelen))  # perfect FQPM for this wavelength
+    osys.addImage(optics.RectangularFieldStop(width=6.0))
+    osys.addPupil(optics.FQPM_FFT_aligner(direction='backward'))
+    osys.addPupil(optics.CircularAperture(radius=radius))
     osys.addDetector(pixelscale=0.01, fov_arcsec=10.0)
 
-    psf = osys.calcPSF(wavelength=wavelen, oversample=oversamp)
-    assert psf[0].data.sum() <  0.002
-    #_log.info("post-FQPM flux is appropriately low.")
-
-
+    psf = osys.calcPSF(wavelength=wavelen)
+    assert psf[0].data.sum() < 0.002
 
 def test_SAMC(oversample=4):
     """ Test semianalytic coronagraphic method
@@ -160,7 +157,7 @@ def test_SAMC(oversample=4):
 
 
 
-def test_parity_FFT_forward_inverse(display = False):
+def test_parity_FFT_forward_inverse(display=False):
     """ Test that transforming from a pupil, to an image, and back to the pupil
     leaves you with the same pupil as you had in the first place.
 
@@ -178,13 +175,13 @@ def test_parity_FFT_forward_inverse(display = False):
     from .test_core import ParityTestAperture
 
     # set up optical system with 2 pupil planes and 2 image planes
-    sys = poppy_core.OpticalSystem()
+    sys = poppy_core.OpticalSystem(oversample=1)
     sys.addPupil(ParityTestAperture())
     sys.addImage()
     sys.addPupil()
     sys.addDetector(pixelscale=0.010, fov_arcsec=1)
 
-    psf, planes = sys.calcPSF(display=display, oversample=1, return_intermediates=True)
+    psf, planes = sys.calcPSF(display=display, return_intermediates=True)
 
     # the wavefronts are padded by 0s. With the current API the most convenient
     # way to ensure we get unpadded versions is via the asFITS function.

--- a/poppy/tests/test_matrixDFT.py
+++ b/poppy/tests/test_matrixDFT.py
@@ -491,7 +491,7 @@ def test_parity_MFT_forward_inverse(display = False):
     sys.addPupil()
     sys.addDetector(pixelscale=pixscale, fov_pixels=npix)
 
-    psf, planes = sys.calcPSF(display=display, oversample=1, return_intermediates=True)
+    psf, planes = sys.calcPSF(display=display, return_intermediates=True)
 
     # the wavefronts are padded by 0s. With the current API the most convenient
     # way to ensure we get unpadded versions is via the asFITS function.


### PR DESCRIPTION
Refactored `OpticalSystem.propagate_mono` / `SemiAnalyticCoronagraph.propagate_mono` and `OpticalSystem.calcPSF` to separate the concerns of weighting and combining simulated optical planes. `propagate_mono` now knows nothing about the wavelength weights, and `calcPSF` does the combining of both the final product and the intermediate planes. As part of this refactoring, calculations with multiprocessing gained the ability to return their intermediate optical planes.