### PR TITLE
Enable Travis-CI for POPPY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 
 python:
-    # - 2.6
     - 2.7
-    # - 3.2
     # - 3.3
     # - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
@@ -22,7 +20,7 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2. 
+        # Do a coverage test in Python 2.
         - python: 2.7
           env: SETUP_CMD='test --coverage'
 
@@ -32,34 +30,26 @@ matrix:
           env: SETUP_CMD='build_sphinx -w'
 
         # Try Astropy development version
-        # - python: 2.7
-        #   env: ASTROPY_VERSION=development SETUP_CMD='test'
+        - python: 2.7
+          env: ASTROPY_VERSION=development SETUP_CMD='test'
         # - python: 3.3
         #   env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
-        # - python: 2.6
-        #   env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
-        # - python: 3.2
-        #   env: SETUP_CMD='test'
         # - python: 3.3
         #   env: SETUP_CMD='test'
         # - python: 3.4
         #   env: SETUP_CMD='test'
 
         # Try older numpy versions
-        # - python: 3.2
-        #   env: NUMPY_VERSION=1.6 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.5 SETUP_CMD='test'
 
 before_install:
 
@@ -72,6 +62,9 @@ before_install:
     - export PATH=/home/travis/miniconda/bin:$PATH
     - conda update --yes conda
 
+    # UPDATE APT-GET LISTINGS
+    - sudo apt-get update
+
     # DOCUMENTATION DEPENDENCIES
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
@@ -82,7 +75,7 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY
@@ -94,7 +87,7 @@ install:
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
-    # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib scipy ; fi
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
 
     # DOCUMENTATION DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,9 @@ env:
 
 matrix:
     include:
-
         # Do a coverage test in Python 2.
         - python: 2.7
           env: SETUP_CMD='test --coverage'
-
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
@@ -75,19 +73,19 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
+    - $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2
+    - $PIP_INSTALL pytest-xdist
 
     # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    - if [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
+    - if [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib scipy ; fi
+    - $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib scipy
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
 
     # DOCUMENTATION DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,9 @@ matrix:
         # - python: 3.4
         #   env: SETUP_CMD='test'
 
-        # Try older numpy versions
+        # Try older numpy version
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 before_install:
 


### PR DESCRIPTION
I edited the `.travis.yml` template from Astropy to test only on NumPy 1.9 and 1.8, and to install our dependencies before running `egg_info` (the lack of which was killing the builds).

Now the build failures appear to actually be test failures (things that are trying to open plot windows and can't, for example).