### PR TITLE
Fix discrepancy pointed out by Anand in matrixDFT

### DIFF
--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -142,11 +142,11 @@ def matrix_dft(plane, nlamD, npix,
     if inverse:
         dX = nlamDX / float(npupX)
         dY = nlamDY / float(npupY)
-        dU = 1.0 / float(npixY)
-        dV = 1.0 / float(npixX)
+        dU = 1.0 / float(npixX)
+        dV = 1.0 / float(npixY)
     else:
         dU = nlamDX / float(npixX)
-        dV = nlamDX / float(npixX)
+        dV = nlamDY / float(npixY)
         dX = 1.0 / float(npupX)
         dY = 1.0 / float(npupY)
 


### PR DESCRIPTION
It looks like we had a copy-pasted line in matrixDFT that wasn't doing what it was supposed to. There's a comment in the file saying
```
    # In the following: X and Y are coordinates in the input plane 
    #                   U and V are coordinates in the output plane 
```
with the implication being that X<->U and Y<->V, but the code didn't match.