### PR TITLE
Colorbar orientation fixes

### DIFF
--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -89,6 +89,10 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
         `matplotlib.rcParams['image.cmap']` (or matplotlib's default).
     ax : matplotlib.Axes instance
         Axes to display into.
+    return_ax : bool
+        Return the axes to the caller for later use? (Default: False)
+        When True, this function returns a matplotlib.Axes instance, or a
+        tuple of (ax, cb) where the second is the colorbar Axes.
     title : string, optional
     imagecrop : float
         size of region to display (default is whole image)

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -63,10 +63,11 @@ def imshow_with_mouseover(image, ax=None,  *args, **kwargs):
 
 
 def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
-                scale='log', cmap=matplotlib.cm.jet, title=None,
-                imagecrop=None, adjust_for_oversampling=False, normalize='None',
+                scale='log', cmap=None, title=None, imagecrop=None,
+                adjust_for_oversampling=False, normalize='None',
                 crosshairs=False, markcentroid=False, colorbar=True,
-                pixelscale='PIXELSCL', ax=None, return_ax=False):
+                colorbar_orientation='vertical', pixelscale='PIXELSCL',
+                ax=None, return_ax=False):
     """Display nicely a PSF from a given HDUlist or filename 
 
     This is extensively configurable. In addition to making an attractive display, for
@@ -83,8 +84,9 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
         min and max for image display scaling
     scale : str
         'linear' or 'log', default is log
-    cmap : matplotlib.cm.Colormap instance
-        Colormap to use. Default is matplotlib.cm.jet
+    cmap : matplotlib.cm.Colormap instance or None
+        Colormap to use. If not given, taken from user's
+        `matplotlib.rcParams['image.cmap']` (or matplotlib's default).
     ax : matplotlib.Axes instance
         Axes to display into.
     title : string, optional
@@ -100,7 +102,11 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
         Draw a crosshairs at the image centroid location?
         Centroiding is computed with the JWST-standard moving box algorithm.
     colorbar : bool
-        Draw a colorbar to the right of the image?
+        Draw a colorbar on the image?
+    colorbar_orientation : 'vertical' (default) or 'horizontal'
+        How should the colorbar be oriented? (Note: Updating a plot and
+        changing the colorbar orientation is not supported. When replotting
+        in the same axes, use the same colorbar orientation.)
     pixelscale : str or float
         if str, interpreted as the FITS keyword name for the pixel scale in arcsec/pixels.
         if float, used as the pixelscale directly.


### PR DESCRIPTION
Addresses #21 with a combination of a hack to retrieve colorbar axes and a warning not to expect too much in the docstring. Calling `display_PSF` with `colorbar_orientation='vertical'` and then again on the same axes with `colorbar_orientation='horizontal'` is not an error (because it's impossible to reliably detect), but *will* make your colorbar look funky.

This is an improvement on the previous state of affairs, where calling `display_PSF` more than once on *any* axes with a colorbar option would make your plot look weird.

This pull request also includes minor tweaks to the handling of the `cmap` keyword argument. The user's default colormap will be used for `display_PSF` unless otherwise specified. `display_PSF_difference` has gained a `cmap` keyword argument for consistency with `display_PSF`, but defaults to the gray colormap unless otherwise specified.