### PR TITLE
Divide by two instead of one in the measure_EE function

### DIFF
--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -23,7 +23,7 @@ For a list of contributors, see :ref:`about`.
    * Unnecessary DeprecationWarnings in imshow_with_mouseover (`#53 <https://github.com/mperrin/poppy/issues/53>`_)
    * Error in saving intermediate planes during calculation (`#81 <https://github.com/mperrin/poppy/issues/81>`_)
    * Multiprocessing causes Python to hang if used with Apple Accelerate (`#23 <https://github.com/mperrin/poppy/issues/23>`_)
-
+   * Error in the ``poppy.utils.measure_EE`` function produced values for the edges of the radial bins that were too large, biasing EE values and leading to weird interpolation behavior near r = 0. (`#96 <https://github.com/mperrin/poppy/pull/96>`_)
 
 
 

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -601,8 +601,8 @@ def measure_EE(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
     rr, radialprofile2, EE = radial_profile(HDUlist_or_filename, ext, EE=True, center=center, binsize=binsize)
 
     # append the zero at the center
-    rr_EE = rr + (rr[1]-rr[0])/1  # add half a binsize to this, because the EE is measured inside the
-                                  # outer edge of each annulus.
+    rr_EE = rr + (rr[1] - rr[0]) / 2.0  # add half a binsize to this, because the EE is measured inside the
+                                        # outer edge of each annulus.
     rr0 = np.concatenate( ([0], rr_EE))
     EE0 = np.concatenate( ([0], EE))
 


### PR DESCRIPTION
This seems to be the explanation for the negative encircled energies I was seeing. The EE was dropping "too fast" because the radii had been shifted up a bit too far, and the interpolator added a negative dip between (0, 0) and the first measured value to compensate.