### PR TITLE
Infer FITSOpticalElement planetype from header keywords when not given

### DIFF
--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -6,16 +6,15 @@ For a list of contributors, see :ref:`about`.
 
 .. _whatsnew:
 
-0.3.5 (or 0.4.0)?
---------------------
+0.3.5 *in development*
+----------------------
 
-2015 April Sometime
-
- * Now compatible with Python 3.4 in addition to 2.7!  ( `#83 <https://github.com/mperrin/poppy/pull/82>`_, @josephoenix)
+ * Now compatible with Python 3.4 in addition to 2.7!  (`#83 <https://github.com/mperrin/poppy/pull/82>`_, @josephoenix)
  * Updated version numbers for dependencies (@josephoenix)
  * Update to most recent astropy package template (@josephoenix)
  * AsymmetricSecondaryObscuration enhanced to allow secondary mirror supports offset from the center of the optical system. (@mperrin)
  * display() functions now return Matplotlib.Axes instances to the calling functions.
+ * FITSOpticalElement will now determine if you are initializing a pupil plane optic or image plane optic based on the presence of a PUPLSCAL or PIXSCALE header keyword in the supplied transmission or OPD files (with the transmission file header taking precedence). (`#97 <https://github.com/mperrin/poppy/pull/97>`_, @josephoenix)
  * Various small documentation updates
  * Bug fixes for: 
 

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -672,7 +672,7 @@ class Instrument(object):
                 key = self._getSpecCacheKey(source, nlambda)
                 if key in self._spectra_cache:
                     poppy_core._log.debug("Previously computed spectral weights found in cache, just reusing those")
-                    return self._spectra_cache[keys]
+                    return self._spectra_cache[key]
             except KeyError:
                 pass  # in case sourcespectrum lacks a name element so the above lookup fails - just do the below calc.
 


### PR DESCRIPTION
FITSOpticalElements are allowed to be initialized with a `planetype` of `None`, which confused the logic to look up the pixel scale from a header keyword. This PR changes it to set the planetype based on whether PUPLSCAL or PIXSCALE are found in the FITS header, with the amplitude/transmission header taking precedence.

This also includes a fix and test case for a typo in `poppy.Instrument`, where the spectra cache was not being exercised (masking a NameError from a typo'ed variable name).