### PR TITLE
(Re-)Optimizes Zernike computation

### DIFF
--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -1,5 +1,6 @@
 import numpy as np
 from poppy import poppy_core
+from poppy import optics
 from poppy import zernike
 
 def test_zernikes_rms(nterms=10, size=500):
@@ -23,6 +24,35 @@ def test_ones_zernikes(nterms=10):
         print("j=%d\tZ_(%d,%d) [1] = \t %s" % (j, n, m, str(Rs)))
         assert Rs[0] == Rs[1] == Rs[2], "Radial polynomial is not radially symmetric"
 
+def test_cached_zernike1(nterms=10):
+    radius = 1.1
+
+    osys = poppy_core.OpticalSystem()
+    osys.addPupil(optics.CircularAperture(radius=radius))
+    wave = osys.inputWavefront()
+
+    y, x = wave.coordinates()
+    rho = np.sqrt(y**2 + x**2) / radius
+    theta = np.arctan2(y, x)
+
+    cached_results = []
+
+    for j in range(1, nterms + 1):
+        cached_output = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, mask_outside=False, outside=0.0)
+        cached_results.append(cached_output)
+        uncached_output = zernike.zernike1(j, rho=rho, theta=theta, mask_outside=False, outside=0.0)
+        assert np.allclose(cached_output, uncached_output)
+
+    try:
+        cached_output[0,0] = np.nan
+        assert False, "Shouldn't be able to assign to a cached output array!"
+    except ValueError:
+        pass
+
+    # Check that we're getting cached copies
+    for j, array_ref in enumerate(cached_results, start=1):
+        cached_array_ref = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, mask_outside=False, outside=0.0)
+        assert id(array_ref) == id(cached_array_ref), "cached_zernike1 returned a new array object for the same arguments"
 
 def _test_cross_zernikes(testj=4, nterms=10, npix=500):
     """Verify the functions are orthogonal, by taking the

--- a/poppy/vendor/lru_cache.py
+++ b/poppy/vendor/lru_cache.py
@@ -5,6 +5,31 @@ Full featured backport from Python 3.3. It passes the 3.3 test suite.
 Full-featured O(1) LRU cache backported from Python3.3. The full Py3.3 API is supported (thread 
 safety, maxsize, keyword args, type checking, __wrapped__, and cache_info). Includes Py3.3 
 optimizations for better memory utilization, fewer dependencies, and fewer dict lookups.
+
+http://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
+Created by Raymond Hettinger on Sat, 17 Mar 2012
+
+The MIT License (MIT)
+
+Copyright (c) 2012 Raymond Hettinger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 """
 
 from collections import namedtuple

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -155,10 +155,11 @@ class ZernikeWFE(WavefrontError):
 
         combined_zernikes = np.zeros(wave.shape, dtype=np.float64)
         for j, k in enumerate(self.coefficients, start=1):
-            combined_zernikes += k * zernike.zernike1(
+            combined_zernikes += k * zernike.cached_zernike1(
                 j,
-                rho=rho,
-                theta=theta,
+                wave.shape,
+                wave.pixelscale,
+                self.radius,
                 mask_outside=False,
                 outside=0.0
             )

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -36,6 +36,8 @@ if sys.version_info > (3, 2):
 else:
     from poppy.vendor.lru_cache import lru_cache
 
+from poppy.poppy_core import Wavefront
+
 import logging
 
 _log = logging.getLogger(__name__)
@@ -288,22 +290,7 @@ def zernike1(j, **kwargs):
 
 @lru_cache()
 def cached_zernike1(j, shape, pixelscale, pupil_radius, mask_outside=True, outside=np.nan, noll_normalize=True):
-    # n.b. this duplicates a subset of functionality from
-    # Wavefront.coordinates(), but we need hashable types in the function
-    # signature for caching
-    y, x = np.indices(shape, dtype=np.float64)
-    y -= (shape[0] - 1) / 2.
-    x -= (shape[1] - 1) / 2.
-    if not np.isscalar(pixelscale):
-        xscale = pixelscale[0]
-        yscale = pixelscale[1]
-    else:
-        xscale = pixelscale
-        yscale = pixelscale
-    y *= yscale
-    x *= xscale
-    # end duplicated functionality
-
+    y, x = Wavefront.pupil_coordinates(shape, pixelscale)
     r = np.sqrt(x ** 2 + y ** 2)
 
     rho = r / pupil_radius


### PR DESCRIPTION
Using the LRU cache decorator from Python 3.2+ (and a vendored copy in `poppy.vendor.lru_cache` for back-compatibility), cache individual Zernike polynomial arrays to speed ZernikeWFE computations.

This adds a test case that generates an input wavefront and compares calling `zernike1()` with `rho` and `theta` arrays (the way previous implementation did, but alas un-cacheable) to a new style where we pass in enough information to reproduce the rho and theta aways within `cached_zernike1()`.

~~The performance improvements ended up being "modest" (that is, ~2x), so there may be further productive profiling to be done.~~ Performance improved by a factor of ~6x for code that used zernike1 a lot.

An obvious next step would be to cache ZernikeWFE phasors with an internal instance attribute and some way to mark it dirty when `self.coefficients` or `self.radius` are assigned to (or make those attributes read-only).