### PR TITLE
Implement PlaneType with an Enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,8 @@ install:
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
-    - $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib scipy
-    # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib scipy; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL six enum34; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1,25 +1,24 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 import multiprocessing
 import copy
+import time
+import enum
+
 import six
+
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.ndimage.interpolation
 import matplotlib
-import time
 
 import astropy.io.fits as fits
-
 
 from .matrixDFT import MatrixFourierTransform
 from . import utils
 from . import conf
 
-
-
 import logging
 _log = logging.getLogger('poppy')
-
 
 __all__ = ['Wavefront',  'OpticalSystem', 'SemiAnalyticCoronagraph', 'OpticalElement', 'FITSOpticalElement', 'Rotation', 'Detector' ]
 
@@ -34,17 +33,18 @@ except ImportError:
     _FFTW_AVAILABLE = False
 
 # internal constants for types of plane
-_PUPIL = 'PUPIL'
-_IMAGE = 'IMAGE'
-_DETECTOR = 'DETECTOR' # specialized type of image plane.
-_ROTATION = 'ROTATION' # not a real optic, just a coordinate transform
-#_typestrs = {0:'', 1:'Pupil plane', 2:'Image plane', 3:'Detector', 4:'Rotation', 'PUPIL':'Pupil plane','IMAGE':'Image plane'}
+class PlaneType(enum.Enum):
+    pupil = 1
+    image = 2
+    detector = 3
+    rotation = 4
 
+_PUPIL = PlaneType.pupil
+_IMAGE = PlaneType.image
+_DETECTOR = PlaneType.detector  # specialized type of image plane
+_ROTATION = PlaneType.rotation  # not a real optic, just a coordinate transform
 
-#conversions
 _RADIANStoARCSEC = 180.*60*60 / np.pi
-
-
 
 #------ Utility functions for parallelization ------
 
@@ -1259,7 +1259,7 @@ class OpticalSystem(object):
                 wavefront.normalize()
                 wavefront *= np.sqrt(2)
             elif normalize.lower()=='exit_pupil': # normalize the last pupil in the system to 1
-                last_pupil_plane_index = np.where(np.asarray([p.planetype =='PUPIL' for p in self.planes]))[0].max() +1
+                last_pupil_plane_index = np.where(np.asarray([p.planetype is PlaneType.pupil for p in self.planes]))[0].max() +1
                 if current_plane_index == last_pupil_plane_index:
                     wavefront.normalize()
                     _log.debug("normalizing at exit pupil (plane {0}) to 1.0 total intensity".format(current_plane_index))

--- a/setup.py
+++ b/setup.py
@@ -104,18 +104,24 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
+install_requires_packages = [
+      'six>=1.7.3',
+      'numpy>=1.8.0',
+      'scipy>=0.14.0',
+      'matplotlib>=1.3.0',
+      'astropy>=1.0.1',
+]
+
+# Python 3.4.x backports
+if sys.version_info[:2] < (3, 4):
+    install_requires_packages.append('enum34>=1.0.4')
+
 setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
       setup_requires=['numpy>=1.8.0', 'astropy>=1.0.1'],
-      install_requires=[
-          'six>=1.7.3',
-          'numpy>=1.8.0',
-          'scipy>=0.14.0',
-          'matplotlib>=1.3.0',
-          'astropy>=1.0.1'
-      ],
+      install_requires=install_requires_packages,
       provides=[PACKAGENAME],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
Introduces a dependency on the Python 3.4+ `enum` module, but the `enum34` backport is there as a dependency for older versions.