### PR TITLE
Add a hook for inserting aberration optics after the pupil

### DIFF
--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -474,7 +474,7 @@ class Instrument(object):
 
 
         #---- apply pupil intensity and OPD to the optical model
-        optsys.addPupil(name='Entrance Pupil', optic=pupil_optic, transmission=full_pupil_path, opd=full_opd_path, opdunits='micron', rotation=self._rotation)
+        optsys.addPupil(name='Entrance Pupil', optic=pupil_optic, transmission=full_pupil_path, opd=full_opd_path, rotation=self._rotation)
 
         # Allow instrument subclass to add field-dependent aberrations
         aberration_optic = self.get_aberrations()

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -476,6 +476,10 @@ class Instrument(object):
         #---- apply pupil intensity and OPD to the optical model
         optsys.addPupil(name='Entrance Pupil', optic=pupil_optic, transmission=full_pupil_path, opd=full_opd_path, opdunits='micron', rotation=self._rotation)
 
+        # Allow instrument subclass to add field-dependent aberrations
+        aberration_optic = self.get_aberrations()
+        if aberration_optic is not None:
+            optsys.addPupil(aberration_optic)
 
         #--- add the detector element. 
         if fov_pixels is None:
@@ -487,6 +491,24 @@ class Instrument(object):
         optsys.addDetector(self.pixelscale, fov_pixels = fov_pixels, oversample = detector_oversample, name=self.name+" detector")
 
         return optsys
+
+    def get_aberrations(self, options):
+        """Incorporate a pupil-plane optic that represents optical aberrations
+        (e.g. field-dependence as an OPD map). Subclasses should override this method.
+        (If no aberration optic should be applied, None should be returned.)
+
+        Parameters
+        ----------
+        options : dict
+            Options dictionary for the instrument (e.g. to specify a pixel position)
+
+        Returns
+        -------
+        aberration_optic : poppy.OpticalElement subclass or None
+            Optional. Will be added to the optical system immediately after the
+            entrance pupil (and any pupil OPD map).
+        """
+        return None
 
     def _applyJitter(self, result, local_options=None):
         """ Modify a PSF to account for the blurring effects of image jitter.

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -492,15 +492,10 @@ class Instrument(object):
 
         return optsys
 
-    def get_aberrations(self, options):
+    def get_aberrations(self):
         """Incorporate a pupil-plane optic that represents optical aberrations
         (e.g. field-dependence as an OPD map). Subclasses should override this method.
         (If no aberration optic should be applied, None should be returned.)
-
-        Parameters
-        ----------
-        options : dict
-            Options dictionary for the instrument (e.g. to specify a pixel position)
 
         Returns
         -------

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -477,7 +477,7 @@ class Instrument(object):
         optsys.addPupil(name='Entrance Pupil', optic=pupil_optic, transmission=full_pupil_path, opd=full_opd_path, rotation=self._rotation)
 
         # Allow instrument subclass to add field-dependent aberrations
-        aberration_optic = self.get_aberrations()
+        aberration_optic = self._get_aberrations()
         if aberration_optic is not None:
             optsys.addPupil(aberration_optic)
 
@@ -492,7 +492,7 @@ class Instrument(object):
 
         return optsys
 
-    def get_aberrations(self):
+    def _get_aberrations(self):
         """Incorporate a pupil-plane optic that represents optical aberrations
         (e.g. field-dependence as an OPD map). Subclasses should override this method.
         (If no aberration optic should be applied, None should be returned.)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2149,8 +2149,6 @@ class FITSOpticalElement(OpticalElement):
                 _log.info("No info supplied on amplitude transmission; assuming uniform throughput = 1")
                 self.amplitude = np.ones(self.opd.shape)
 
-            # convert OPD into meters
-
             if opdunits is None:
                 try:
                     opdunits = self.opd_header['BUNIT']
@@ -2158,13 +2156,17 @@ class FITSOpticalElement(OpticalElement):
                     _log.error("No opdunit keyword supplied, and BUNIT keyword not found in header. Cannot determine OPD units")
                     raise Exception("No opdunit keyword supplied, and BUNIT keyword not found in header. Cannot determine OPD units.")
 
+            # normalize and drop any trailing 's'
             opdunits = opdunits.lower()
-            # rescale to meters if necessary
-            if opdunits in ('meter', 'meters', 'm'):
+            if opdunits.endswith('s'):
+                opdunits = opdunits[:-1]
+
+            # rescale OPD to meters if necessary
+            if opdunits in ('meter', 'm'):
                 pass
-            elif opdunits in ('micron', 'microns', 'um', 'micrometer', 'micrometers'):
+            elif opdunits in ('micron', 'um', 'micrometer'):
                 self.opd *= 1e-6
-            elif opdunits in ('nanometer', 'nanometers', 'nm'):
+            elif opdunits in ('nanometer', 'nm'):
                 self.opd *= 1e-9
 
             if len (self.opd.shape) != 2 or self.opd.shape[0] != self.opd.shape[1]:

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2048,7 +2048,7 @@ class FITSOpticalElement(OpticalElement):
 
     """
 
-    def __init__(self, name="unnamed optic", transmission=None, opd= None, opdunits="meters",
+    def __init__(self, name="unnamed optic", transmission=None, opd=None, opdunits=None,
             shift=None, rotation=None, pixelscale=None, planetype=None,
             transmission_index=None, opd_index=None,
             **kwargs):
@@ -2158,16 +2158,14 @@ class FITSOpticalElement(OpticalElement):
                     _log.error("No opdunit keyword supplied, and BUNIT keyword not found in header. Cannot determine OPD units")
                     raise Exception("No opdunit keyword supplied, and BUNIT keyword not found in header. Cannot determine OPD units.")
 
-
-            if opdunits.lower().endswith('s'): opdunits = opdunits[:-1] # drop trailing s if present
-            if opdunits.lower() == 'meter' or opdunits.lower() == 'm':
-                pass # no need to rescale
-            elif opdunits.lower() == 'micron' or opdunits.lower() == 'um' or opdunits.lower() == 'micrometer':
+            opdunits = opdunits.lower()
+            # rescale to meters if necessary
+            if opdunits in ('meter', 'meters', 'm'):
+                pass
+            elif opdunits in ('micron', 'microns', 'um', 'micrometer', 'micrometers'):
                 self.opd *= 1e-6
-            elif opdunits.lower() == 'nanometer' or opdunits.lower() == 'nm':
+            elif opdunits in ('nanometer', 'nanometers', 'nm'):
                 self.opd *= 1e-9
-
-
 
             if len (self.opd.shape) != 2 or self.opd.shape[0] != self.opd.shape[1]:
                 _log.debug('OPD shape: '+str(self.opd.shape))


### PR DESCRIPTION
Adds `poppy.Instrument.get_aberrations` which returns a `poppy.OpticalElement` or `None`. Used in the implementation of the WFIRST WFI model.

Additionally, lets POPPY select the units of OPD based on a FITS header keyword instead of forcing them to be microns.