### PR TITLE
Factor out the Fresnel-specific stuff from Wavefront.display a little bit

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -237,12 +237,17 @@ class FresnelWavefront(Wavefront):
             raise ValueError("Input wavefront needs to be a pupil plane in units of m/pix. Specify a diameter not a pixelscale.")
 
     def display(self, *args, **kwargs):
-        # Is this FresnelWavefront in angular units?
-        return super(FresnelWavefront, self).display(
-            *args,
-            use_angular_coordinates=self.angular_coordinates,
-            **kwargs
-        )
+        if not 'use_angular_coordinates' in kwargs:
+            # Is this FresnelWavefront in angular units?
+            return super(FresnelWavefront, self).display(
+                *args,
+                use_angular_coordinates=self.angular_coordinates,
+                **kwargs
+            )
+        else:
+            return super(FresnelWavefront, self).display(
+                *args, **kwargs
+            )
     display.__doc__ = Wavefront.display.__doc__
 
     # properties and methods supporting fresnel propagation

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -355,9 +355,10 @@ class Wavefront(object):
         use_angular_coordinates : bool, optional
             Should the axes be labeled in angular units of arcseconds?
             This is used by FresnelWavefront, where non-angular
-            coordinates are possible everywhere. Behavior for Wavefront
-            is undefined.
-            (Default: None, infer coordinates from PlaneType)
+            coordinates are possible everywhere. When using Fraunhofer
+            propagation, this should be left as None so that the
+            coordinates are inferred from the planetype attribute.
+            (Default: None, infer coordinates from planetype)
 
         Returns
         -------

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -326,7 +326,8 @@ class Wavefront(object):
         self.asFITS(**kwargs).writeto(filename, clobber=clobber)
         _log.info("  Wavefront saved to %s" % filename)
 
-    def display(self,what='intensity', nrows=1,row=1,showpadding=False,imagecrop=None, colorbar=False, crosshairs=True, ax=None, title=None,vmin=1e-8,vmax=1e0):
+    def display(self, what='intensity', nrows=1, row=1, showpadding=False, imagecrop=None,
+                colorbar=False, crosshairs=True, ax=None, title=None, vmin=1e-8, vmax=1e0, use_angular_coordinates=None):
         """Display wavefront on screen
 
         Parameters
@@ -351,13 +352,17 @@ class Wavefront(object):
             Display colorbar
         ax : matplotlib Axes
             axes to display into
+        use_angular_coordinates : bool, optional
+            Should the axes be labeled in angular units of arcseconds?
+            This is used by FresnelWavefront, where non-angular
+            coordinates are possible everywhere. Behavior for Wavefront
+            is undefined.
+            (Default: None, infer coordinates from PlaneType)
 
         Returns
         -------
         figure : matplotlib figure
             The current figure is modified.
-
-
         """
         if imagecrop is None: imagecrop = conf.default_image_display_fov
 
@@ -384,13 +389,10 @@ class Wavefront(object):
 
         extent = [x.min()-halfpix, x.max()+halfpix, y.min()-halfpix, y.max()+halfpix]
 
-        if hasattr(self, 'angular_coordinates'):
-            is_angular = self.angular_coordinates  # compatibility hook for FresnelWavefront subclass
-        else:
-            is_angular = self.planetype==PlaneType.image
+        if use_angular_coordinates is None:
+            use_angular_coordinates = self.planetype == _IMAGE
 
-
-        if not is_angular:
+        if not use_angular_coordinates:
             unit = "m"
         else:
             halffov_x = intens.shape[1]/2.*self.pixelscale #for use later in cropping
@@ -436,7 +438,7 @@ class Wavefront(object):
             ax.set_xlabel(unit)
             if colorbar: plt.colorbar(ax.images[0], orientation='vertical', shrink=0.8)
 
-            if is_angular:
+            if use_angular_coordinates:
                 if crosshairs:
                     plt.axhline(0,ls=":", color='k')
                     plt.axvline(0,ls=":", color='k')

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -3,7 +3,7 @@ from .. import optics
 from .. import misc
 from .. import fresnel
 from .. import utils
-from poppy.poppy_core import _log
+from poppy.poppy_core import _log, PlaneType
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -261,10 +261,24 @@ def test_fresnel_optical_system_Hubble(display=False):
     assert(np.abs((measured_fwhm-expected_fwhm)/expected_fwhm) < 0.05)
 
     ### check the various plane types are as expected, including toggling into angular coordinates
-    pt = poppy_core.PlaneType
-    assert(np.allclose([w.planetype for w in waves], [pt.pupil, pt.pupil, pt.intermediate, pt.image]))
-    assert(np.allclose([w.angular_coordinates for w in waves], [False, False, False, True]))
-    assert(np.allclose([w.spherical for w in waves], [False, True, True, False]))
+    assert_message = ("Expected FresnelWavefront at plane #{} to have {} == {}, but got {}")
+    system_planetypes = [PlaneType.pupil, PlaneType.pupil, PlaneType.intermediate, PlaneType.image]
+    for idx, (wavefront, planetype) in enumerate(zip(waves, system_planetypes)):
+        assert wavefront.planetype == planetype, assert_message.format(
+            idx, "planetype", plane_type, wavefront.planetype
+        )
+
+    angular_coordinates_flags = [False, False, False, True]
+    for idx, (wavefront, angular_coordinates) in enumerate(zip(waves, angular_coordinates_flags)):
+        assert wavefront.angular_coordinates == angular_coordinates, assert_message.format(
+            idx, "angular_coordinates", angular_coordinates, wavefront.angular_coordinates
+        )
+
+    spherical_flags = [False, True, True, False]
+    for idx, (wavefront, spherical) in enumerate(zip(waves, angular_coordinates_flags)):
+        assert wavefront.spherical == spherical, assert_message.format(
+            idx, "spherical", spherical, wavefront.spherical
+        )
 
     ### and check that the resulting function is a 2D Airy function
     #create an airy function matching the center part of this array


### PR DESCRIPTION
Now Wavefront.display doesn't need to know anything about attribute names on FresnelWavefront, pushing the responsibility down (up?) a level to FresnelWavefront.display to request angular units when appropriate.

(Pull requests within pull requests... First time I've done this, but didn't want to push indiscriminately to mperrin/poppy@fresnel!)