### PR TITLE
Add the opd_expand function to poppy.zernike

### DIFF
--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -137,12 +137,12 @@ def test_cross_hexikes():
     for testj in (2, 3, 4, 5, 6):
         _test_cross_hexikes(testj=testj, nterms=6)
 
-def test_wf_expand(npix=512, input_coefficients=[0.1, 0.2, 0.3, 0.4, 0.5]):
+def test_opd_expand(npix=512, input_coefficients=[0.1, 0.2, 0.3, 0.4, 0.5]):
     basis = zernike.zernike_basis(nterms=len(input_coefficients), npix=npix)
     for idx, coeff in enumerate(input_coefficients):
         basis[idx] *= coeff
 
-    wf = basis.sum(axis=0)
-    recovered_coeffs = zernike.wf_expand(wf, nterms=len(input_coefficients))
+    opd = basis.sum(axis=0)
+    recovered_coeffs = zernike.opd_expand(opd, nterms=len(input_coefficients))
     max_diff = np.max(np.abs(np.asarray(input_coefficients) - np.asarray(recovered_coeffs)))
     assert max_diff < 1e-3, "recovered coefficients from wf_expand more than 0.1% off"

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -38,9 +38,9 @@ def test_cached_zernike1(nterms=10):
     cached_results = []
 
     for j in range(1, nterms + 1):
-        cached_output = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, mask_outside=False, outside=0.0)
+        cached_output = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, outside=0.0)
         cached_results.append(cached_output)
-        uncached_output = zernike.zernike1(j, rho=rho, theta=theta, mask_outside=False, outside=0.0)
+        uncached_output = zernike.zernike1(j, rho=rho, theta=theta, outside=0.0)
         assert np.allclose(cached_output, uncached_output)
 
     try:
@@ -51,7 +51,7 @@ def test_cached_zernike1(nterms=10):
 
     # Check that we're getting cached copies
     for j, array_ref in enumerate(cached_results, start=1):
-        cached_array_ref = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, mask_outside=False, outside=0.0)
+        cached_array_ref = zernike.cached_zernike1(j, wave.shape, wave.pixelscale, radius, outside=0.0)
         assert id(array_ref) == id(cached_array_ref), "cached_zernike1 returned a new array object for the same arguments"
 
 def _test_cross_zernikes(testj=4, nterms=10, npix=500):

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -136,3 +136,13 @@ def test_cross_hexikes():
     """
     for testj in (2, 3, 4, 5, 6):
         _test_cross_hexikes(testj=testj, nterms=6)
+
+def test_wf_expand(npix=512, input_coefficients=[0.1, 0.2, 0.3, 0.4, 0.5]):
+    basis = zernike.zernike_basis(nterms=len(input_coefficients), npix=npix)
+    for idx, coeff in enumerate(input_coefficients):
+        basis[idx] *= coeff
+
+    wf = basis.sum(axis=0)
+    recovered_coeffs = zernike.wf_expand(wf, nterms=len(input_coefficients))
+    max_diff = np.max(np.abs(np.asarray(input_coefficients) - np.asarray(recovered_coeffs)))
+    assert max_diff < 1e-3, "recovered coefficients from wf_expand more than 0.1% off"

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -75,14 +75,21 @@ class ParameterizedWFE(WavefrontError):
         circumscribing the actual pupil shape.
     basis_factory : callable
         basis_factory will be called with the arguments `nterms`, `rho`,
-        and `theta`. `nterms` specifies how many terms to compute,
-        starting with the j=1 term in the Noll indexing convention for
-        `nterms` = 1 and counting up. `rho` and `theta` are square
-        arrays holding the rho and theta coordinates at each pixel in
-        the pupil plane.
+        `theta`, and `outside`.
 
-        `rho` is normalized such that `rho` == 1.0 for pixels at
-        `radius` meters from the center.
+        `nterms` specifies how many terms to compute, starting with the
+        j=1 term in the Noll indexing convention for `nterms` = 1 and
+        counting up.
+
+        `rho` and `theta` are square arrays holding the rho and theta
+        coordinates at each pixel in the pupil plane. `rho` is
+        normalized such that `rho` == 1.0 for pixels at `radius` meters
+        from the center.
+
+        `outside` contains the value to assign pixels outside the
+        radius `rho` == 1.0. (Always 0.0, but provided for
+        compatibility with `zernike.zernike_basis` and
+        `zernike.hexike_basis`.)
     """
     def __init__(self, name="Parameterized Distortion", coefficients=None, radius=None,
                  basis_factory=None, **kwargs):
@@ -103,7 +110,7 @@ class ParameterizedWFE(WavefrontError):
         combined_distortion = np.zeros(rho.shape)
 
         nterms = len(self.coefficients)
-        computed_terms = self.basis_factory(nterms=nterms, rho=rho, theta=theta)
+        computed_terms = self.basis_factory(nterms=nterms, rho=rho, theta=theta, outside=0.0)
 
         for idx, coefficient in enumerate(self.coefficients):
             if coefficient == 0.0:
@@ -160,7 +167,6 @@ class ZernikeWFE(WavefrontError):
                 wave.shape,
                 wave.pixelscale,
                 self.radius,
-                mask_outside=False,
                 outside=0.0
             )
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -308,8 +308,9 @@ def zernike_basis(nterms=15, npix=512, rho=None, theta=None, **kwargs):
         Desired pixel diameter for circular pupil. Only used if `rho`
         and `theta` are not provided.
     rho, theta : array_like
-        Image plane coordinates. `rho` should be 1.0 at the desired
-        pixel radius, `theta` should be in radians.
+        Image plane coordinates. `rho` should be 0 at the origin
+        and 1.0 at the edge of the circular pupil. `theta` should be
+        the angle in radians.
 
     Other parameters are passed through to `poppy.zernike.zernike`
     and are documented there.

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -436,3 +436,53 @@ def hexike_basis(nterms=15, npix=512, rho=None, theta=None, vertical=False, **kw
 
     # drop the 0th null element, return the rest
     return H[1:]
+
+def wf_expand(wavefront, aperture=None, nterms=15, basis=zernike_basis,
+              **kwargs):
+    """Given a wavefront, return the list of Zernike coefficients that
+    best fit it.
+
+    Parameters
+    ----------
+    wavefront : 2D numpy.ndarray
+        The wavefront to expand in terms of the requested basis.
+        Must be square.
+    aperture : 2D numpy.ndarray, optional
+        ndarray giving the aperture mask to use. If not explicitly
+        specified, all finite points in the wavefront array
+        (i.e. not NaNs) are assumed to define the pupil aperture.
+    nterms : int
+        Number of terms to use. (Default: 15)
+    basis : callable, optional
+        Callable (e.g. a function) that generates a sequence
+        of basis arrays given arguments `nterms` and `npix`. Additional
+        keyword arguments to this function are passed through as well.
+
+    Note: Recovering coefficients used to generate synthetic/test data
+    depends greatly on the sampling (as one might expect). Generating
+    test data using zernike_basis with npix=512 and passing the result
+    through wf_expand reproduces the input coefficients within 0.1%.
+
+    Returns
+    -------
+    coeffs : list
+        List of coefficients (of length `nterms`) from which the
+        input wavefront can be constructed in the given basis.
+        (No additional unit conversions are performed. If the input
+        wavefront is in waves, coeffs will be in waves.)
+    """
+
+    if aperture is None:
+        _log.warn("No aperture supplied - using the nonzero part "
+                  "of the wavefront as a guess.")
+        aperture = np.asarray((wavefront != 0) & np.isfinite(wavefront), dtype=int)
+
+    basis_set =  basis(nterms=nterms, npix=wavefront.shape[0], **kwargs)
+
+    wgood = np.where(aperture & np.isfinite(basis_set[1]))
+    ngood = (wgood[0]).size
+
+    coeffs = [(wavefront * b)[wgood].sum() / ngood
+              for b in basis_set]
+
+    return coeffs

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -170,8 +170,8 @@ def R(n_, m_, rho):
         return output
 
 
-def zernike(n, m, npix=100, rho=None, theta=None, mask_outside=True,
-            outside=np.nan, noll_normalize=True):
+def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
+            noll_normalize=True):
     """Return the Zernike polynomial Z[m,n] for a given pupil.
 
     For this function the desired Zernike is specified by 2 indices m and n.
@@ -194,18 +194,21 @@ def zernike(n, m, npix=100, rho=None, theta=None, mask_outside=True,
     n, m : int
         Zernike function degree
     npix: int
-        Desired diameter for circular pupil. Only used if r and theta are not provided.
+        Desired diameter for circular pupil. Only used if `rho` and
+        `theta` are not provided.
     rho, theta : array_like
-        Image plane coordinates. rho should be in 0<rho<1, theta should be in radians
-    mask_outside : bool
-        Mask out the region beyond radius 1? Default True.
+        Image plane coordinates. `rho` should be 0 at the origin
+        and 1.0 at the edge of the circular pupil. `theta` should be
+        the angle in radians.
     outside : float
-        Value for pixels outside the circular aperture. Default is NaN, but you may also
-        find it useful for this to be zero sometimes.
+        Value for pixels outside the circular aperture (rho > 1).
+        Default is `np.nan`, but you may also find it useful for this to
+        be 0.0 sometimes.
     noll_normalize : bool
-        As defined in Noll et al. JOSA 1976, the Zernikes are normalized such that
-        the integral of Z[n, m] * Z[n, m] over the unit disk is pi exactly. To omit
-        the normalization constant, set this to False. Default is True.
+        As defined in Noll et al. JOSA 1976, the Zernike definition is
+        modified such that the integral of Z[n, m] * Z[n, m] over the
+        unit disk is pi exactly. To omit the normalization constant,
+        set this to False. Default is True.
 
     Returns
     -------
@@ -248,8 +251,6 @@ def zernike(n, m, npix=100, rho=None, theta=None, mask_outside=True,
         zernike_result = norm_coeff * R(n, m, rho) * np.sin(np.abs(m) * theta) * aperture
 
     zernike_result[np.where(rho > 1)] = outside
-    if mask_outside:
-        zernike_result = np.ma.array(zernike_result, mask=(rho > 1), fill_value=np.nan)
     return zernike_result
 
 def zernike1(j, **kwargs):
@@ -265,20 +266,10 @@ def zernike1(j, **kwargs):
     Parameters
     ----------
     j : int
-        Zernike function ordinate, following the convention of Noll et al. JOSA 1976
-    npix: int
-        Desired diameter for circular pupil. Only used if r and theta are not provided.
-    rho, theta : array_like
-        Image plane coordinates. rho should be in 0<rho<1, theta should be in radians
-    mask_outside : bool
-        Mask out the region beyond radius 1? Default True.
-    outside : float
-        Value for pixels outside the circular aperture. Default is NaN, but you may also
-        find it useful for this to be zero sometimes.
-    noll_normalize : bool
-        As defined in Noll et al. JOSA 1976, the Zernike definition is modified such that
-        the integral of Z[n, m] * Z[n, m] over the unit disk is pi exactly. To omit
-        the normalization constant, set this to False. Default is True.
+        Zernike function ordinate, following the convention of
+        Noll et al. JOSA 1976
+
+    Additional arguments are defined as in `poppy.zernike.zernike`.
 
     Returns
     -------
@@ -289,7 +280,7 @@ def zernike1(j, **kwargs):
     return zernike(n, m, **kwargs)
 
 @lru_cache()
-def cached_zernike1(j, shape, pixelscale, pupil_radius, mask_outside=True, outside=np.nan, noll_normalize=True):
+def cached_zernike1(j, shape, pixelscale, pupil_radius, outside=np.nan, noll_normalize=True):
     y, x = Wavefront.pupil_coordinates(shape, pixelscale)
     r = np.sqrt(x ** 2 + y ** 2)
 
@@ -297,7 +288,7 @@ def cached_zernike1(j, shape, pixelscale, pupil_radius, mask_outside=True, outsi
     theta = np.arctan2(y / pupil_radius, x / pupil_radius)
 
     n, m = noll_indices(j)
-    result = zernike(n, m, rho=rho, theta=theta, mask_outside=mask_outside, outside=outside, noll_normalize=noll_normalize)
+    result = zernike(n, m, rho=rho, theta=theta, outside=outside, noll_normalize=noll_normalize)
     result.flags.writeable = False  # don't let caller modify cached copy in-place
     return result
 
@@ -309,33 +300,30 @@ def zernike_basis(nterms=15, npix=512, rho=None, theta=None, **kwargs):
 
     Parameters
     -----------
-    nterms : int
-        Number of Zernike terms to return
+    nterms : int, optional
+        Number of Zernike terms to return, starting from piston.
+        (e.g. ``nterms=1`` would return only the Zernike piston term.)
+        Default is 15.
     npix: int
-        Desired pixel diameter for circular pupil. Only used if r and theta are not provided.
+        Desired pixel diameter for circular pupil. Only used if `rho`
+        and `theta` are not provided.
     rho, theta : array_like
-        Image plane coordinates. `rho` should be 1 at the desired pixel radius,
-        `theta` should be in radians
-    noll_normalize : bool
-        As defined in Noll et al. JOSA 1976, the Zernikes are normalized such that
-        the integral of Z[n, m] * Z[n, m] over the unit disk is pi exactly. To omit
-        the normalization constant, set this to False. Default is True.
+        Image plane coordinates. `rho` should be 1.0 at the desired
+        pixel radius, `theta` should be in radians.
+
+    Other parameters are passed through to `poppy.zernike.zernike`
+    and are documented there.
     """
     if rho is not None:
-        if rho is None or theta is None:
-            raise ValueError("You must supply both `theta` and `rho`, or neither.")
-        npix = rho.shape[0]
+        # both are required, but validated in zernike1
         shape = rho.shape
         use_polar = True
     else:
         shape = (npix, npix)
         use_polar = False
 
-    # pass these keyword arguments through to zernike.zernike
-    kwargs['mask_outside'] = True
-    kwargs['outside'] = 0.0
-
     zern_output = np.zeros((nterms,) + shape)
+
     if use_polar:
         for j in range(nterms):
             zern_output[j] = zernike1(j + 1, rho=rho, theta=theta, **kwargs)
@@ -359,7 +347,7 @@ def hex_aperture(npix=1024, rho=None, theta=None, vertical=False):
         the whole array from edge to edge in the direction aligned
         with its flat sides. (Ignored when `rho` and `theta` are
         supplied.)
-    rho, theta : 2D numpy arrays
+    rho, theta : 2D numpy arrays, optional
         For some square aperture, rho and theta contain each pixel's
         coordinates in polar form. The hexagon will be defined such
         that it can be circumscribed in a rho = 1 circle.
@@ -393,14 +381,38 @@ def hex_aperture(npix=1024, rho=None, theta=None, vertical=False):
         return aperture
 
 
-def hexike_basis(nterms=15, npix=512, rho=None, theta=None, vertical=False, **kwargs):
-    """ Return a list of hexike polynomials 1-N following the
-    method of Mahajan and Dai 2006 """
+def hexike_basis(nterms=15, npix=512, rho=None, theta=None,
+                 vertical=False, outside=np.nan):
+    """Return a list of hexike polynomials 1-N following the
+    method of Mahajan and Dai 2006
+
+    Parameters
+    ----------
+    nterms : int
+        Number of hexike terms to compute, starting from piston.
+        (e.g. ``nterms=1`` would return only the hexike analog to the
+        Zernike piston term.) Default is 15.
+    npix : int
+        Size, in pixels, of the aperture array. The hexagon will span
+        the whole array from edge to edge in the direction aligned
+        with its flat sides.
+    rho, theta : 2D numpy arrays, optional
+        For some square aperture, rho and theta contain each pixel's
+        coordinates in polar form. The hexagon will be defined such
+        that it can be circumscribed in a rho = 1 circle.
+    vertical : bool
+        Make flat sides parallel to the Y axis instead of the default X.
+        Default is False.
+    outside : float
+        Value for pixels outside the hexagonal aperture.
+        Default is 0.0, but you may also find it useful for this to
+        be `np.nan` sometimes.
+    """
 
     if rho is not None:
         shape = rho.shape
-        assert len(shape) == 2 and shape[0] == shape[1], ("only square rho and "
-                                                          "theta arrays supported")
+        assert len(shape) == 2 and shape[0] == shape[1], \
+            "only square rho and theta arrays supported"
     else:
         shape = (npix, npix)
 
@@ -448,20 +460,23 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
         The wavefront OPD map to expand in terms of the requested basis.
         Must be square.
     aperture : 2D numpy.ndarray, optional
-        ndarray giving the aperture mask to use. If not explicitly
-        specified, all finite points in the wavefront array
-        (i.e. not NaNs) are assumed to define the pupil aperture.
+        ndarray giving the aperture mask to use
+        (1.0 where light passes, 0.0 where it is blocked).
+        If not explicitly specified, all finite points in the `opd`
+        array (i.e. not NaNs) are assumed to define the pupil aperture.
     nterms : int
         Number of terms to use. (Default: 15)
     basis : callable, optional
         Callable (e.g. a function) that generates a sequence
-        of basis arrays given arguments `nterms` and `npix`. Additional
-        keyword arguments to this function are passed through as well.
+        of basis arrays given arguments `nterms`, `npix`, and `outside`.
+
+    Additional keyword arguments to this function are passed
+    through to the `basis` callable.
 
     Note: Recovering coefficients used to generate synthetic/test data
     depends greatly on the sampling (as one might expect). Generating
-    test data using zernike_basis with npix=512 and passing the result
-    through opd_expand reproduces the input coefficients within 0.1%.
+    test data using zernike_basis with npix=256 and passing the result
+    through opd_expand reproduces the input coefficients within <0.1%.
 
     Returns
     -------
@@ -473,13 +488,17 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
     """
 
     if aperture is None:
-        _log.warn("No aperture supplied - using the nonzero part "
-                  "of the wavefront as a guess.")
-        aperture = np.asarray((opd != 0) & np.isfinite(opd), dtype=int)
+        _log.warn("No aperture supplied - using the finite (non-NaN) part of the OPD map as a guess.")
+        aperture = np.isfinite(opd).astype(np.float)
 
-    basis_set =  basis(nterms=nterms, npix=opd.shape[0], **kwargs)
+    basis_set = basis(
+        nterms=nterms,
+        npix=opd.shape[0],
+        outside=np.nan,
+        **kwargs
+    )
 
-    wgood = np.where(aperture & np.isfinite(basis_set[1]))
+    wgood = np.where((aperture != 0.0) & np.isfinite(basis_set[1]))
     ngood = (wgood[0]).size
 
     coeffs = [(opd * b)[wgood].sum() / ngood

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -437,15 +437,15 @@ def hexike_basis(nterms=15, npix=512, rho=None, theta=None, vertical=False, **kw
     # drop the 0th null element, return the rest
     return H[1:]
 
-def wf_expand(wavefront, aperture=None, nterms=15, basis=zernike_basis,
+def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
               **kwargs):
-    """Given a wavefront, return the list of Zernike coefficients that
-    best fit it.
+    """Given a wavefront OPD map, return the list of Zernike
+    coefficients that best fit it.
 
     Parameters
     ----------
-    wavefront : 2D numpy.ndarray
-        The wavefront to expand in terms of the requested basis.
+    opd : 2D numpy.ndarray
+        The wavefront OPD map to expand in terms of the requested basis.
         Must be square.
     aperture : 2D numpy.ndarray, optional
         ndarray giving the aperture mask to use. If not explicitly
@@ -461,13 +461,13 @@ def wf_expand(wavefront, aperture=None, nterms=15, basis=zernike_basis,
     Note: Recovering coefficients used to generate synthetic/test data
     depends greatly on the sampling (as one might expect). Generating
     test data using zernike_basis with npix=512 and passing the result
-    through wf_expand reproduces the input coefficients within 0.1%.
+    through opd_expand reproduces the input coefficients within 0.1%.
 
     Returns
     -------
     coeffs : list
         List of coefficients (of length `nterms`) from which the
-        input wavefront can be constructed in the given basis.
+        input OPD map can be constructed in the given basis.
         (No additional unit conversions are performed. If the input
         wavefront is in waves, coeffs will be in waves.)
     """
@@ -475,14 +475,14 @@ def wf_expand(wavefront, aperture=None, nterms=15, basis=zernike_basis,
     if aperture is None:
         _log.warn("No aperture supplied - using the nonzero part "
                   "of the wavefront as a guess.")
-        aperture = np.asarray((wavefront != 0) & np.isfinite(wavefront), dtype=int)
+        aperture = np.asarray((opd != 0) & np.isfinite(opd), dtype=int)
 
-    basis_set =  basis(nterms=nterms, npix=wavefront.shape[0], **kwargs)
+    basis_set =  basis(nterms=nterms, npix=opd.shape[0], **kwargs)
 
     wgood = np.where(aperture & np.isfinite(basis_set[1]))
     ngood = (wgood[0]).size
 
-    coeffs = [(wavefront * b)[wgood].sum() / ngood
+    coeffs = [(opd * b)[wgood].sum() / ngood
               for b in basis_set]
 
     return coeffs

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -451,8 +451,8 @@ def hexike_basis(nterms=15, npix=512, rho=None, theta=None,
 
 def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
               **kwargs):
-    """Given a wavefront OPD map, return the list of Zernike
-    coefficients that best fit it.
+    """Given a wavefront OPD map, return the list of coefficients in a
+    given basis set (by default, Zernikes) that best fit the OPD map.
 
     Parameters
     ----------
@@ -469,6 +469,7 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
     basis : callable, optional
         Callable (e.g. a function) that generates a sequence
         of basis arrays given arguments `nterms`, `npix`, and `outside`.
+        Default is `poppy.zernike.zernike_basis`.
 
     Additional keyword arguments to this function are passed
     through to the `basis` callable.
@@ -488,7 +489,8 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
     """
 
     if aperture is None:
-        _log.warn("No aperture supplied - using the finite (non-NaN) part of the OPD map as a guess.")
+        _log.warn("No aperture supplied - "
+                  "using the finite (non-NaN) part of the OPD map as a guess.")
         aperture = np.isfinite(opd).astype(np.float)
 
     basis_set = basis(


### PR DESCRIPTION
This function (originally by @mperrin) expands a given wavefront OPD array in terms of a given basis set (Zernike by default). This PR also adds a test that verifies input coefficients for a generated OPD array are recovered within 0.1% when sampled at 512 pixels across the wavefront.