### PR TITLE
Handle a corner case in hex_aperture for even and odd npix

### DIFF
--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -136,3 +136,28 @@ def test_cross_hexikes():
     """
     for testj in (2, 3, 4, 5, 6):
         _test_cross_hexikes(testj=testj, nterms=6)
+
+def test_hex_aperture_even_odd_npix():
+    """Issue reported by Alex Greenbaum where even-npix
+    hex apertures had an extra zero column on each side
+    but odd-npix ones did not.
+    
+    In an effort to make the behavior consistent, the `hex_aperture`
+    function now only includes pixels entirely enclosed by the hexagon
+    in the aperture, so the pointiest corner near the array edge will
+    always be chopped off (not included) resulting in a zero column
+    at the edge.
+    """
+    from poppy.zernike import hex_aperture
+
+    odd_hex = hex_aperture(npix=127)
+    assert np.max(odd_hex[:,0]) == 0.0
+    assert np.max(odd_hex[:,1]) == 1.0
+    assert np.max(odd_hex[:,-2]) == 1.0
+    assert np.max(odd_hex[:,-1]) == 0.0
+
+    even_hex = hex_aperture(npix=128)
+    assert np.max(even_hex[:,0]) == 0.0
+    assert np.max(even_hex[:,1]) == 1.0
+    assert np.max(even_hex[:,-2]) == 1.0
+    assert np.max(even_hex[:,-1]) == 0.0

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -359,7 +359,12 @@ def hex_aperture(npix=1024, rho=None, theta=None, vertical=False):
         the whole array from edge to edge in the direction aligned
         with its flat sides. (Ignored when `rho` and `theta` are
         supplied.)
-    rho, theta : 2D numpy arrays
+
+        Note: There will be one zeroed column (or row) flanking the
+        non-flat sides, since only pixels *completely* enclosed in the
+        hexagon will have nonzero values. (If you need anti-aliased
+        hexagons, consider oversampling and then resizing the array.)
+    rho, theta : 2D numpy arrays, optional
         For some square aperture, rho and theta contain each pixel's
         coordinates in polar form. The hexagon will be defined such
         that it can be circumscribed in a rho = 1 circle.
@@ -380,9 +385,9 @@ def hex_aperture(npix=1024, rho=None, theta=None, vertical=False):
     absy = np.abs(y)
 
     aperture = np.zeros(x.shape)
-    w_rect = np.where((np.abs(x) <= 0.5) & (np.abs(y) <= np.sqrt(3) / 2))
-    w_left_tri = np.where((x <= -0.5) & (x >= -1) & (absy <= (x + 1) * np.sqrt(3)))
-    w_right_tri = np.where((x >= 0.5) & (x <= 1) & (absy <= (1 - x) * np.sqrt(3)))
+    w_rect = np.where((np.abs(x) <= 0.5) & (np.abs(y) < np.sqrt(3) / 2))
+    w_left_tri = np.where((x < -0.5) & (x > -1) & (absy < (x + 1) * np.sqrt(3)))
+    w_right_tri = np.where((x > 0.5) & (x < 1) & (absy < (1 - x) * np.sqrt(3)))
     aperture[w_rect] = 1
     aperture[w_left_tri] = 1
     aperture[w_right_tri] = 1


### PR DESCRIPTION
`hex_aperture` was behaving differently depending on even or odd npix values.

The best option we could come up with was picking only pixels entirely enclosed in the hexagon for inclusion in the aperture. Now, even and odd npix values alike will produce the behavior where the corners on the non-flat sides lack a pixel that would take them to the edge of the array. (In other words, hex_aperture arrays have a zero column or row between the corner and the edge of the array.)