### PR TITLE
Fresnel - minor units fix and allow optics to work on non-_PUPIL wavefronts

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -807,7 +807,7 @@ class FresnelWavefront(Wavefront):
             R_output_beam = 1.0/(1.0/self.R_c() - 1.0/optic.fl)
             _log.debug(" input curved wavefront and "+str(optic.name) +" has output beam curvature of ={0:0.2e}".format(R_output_beam))
         else:
-            R_input_beam = np.inf
+            R_input_beam = np.inf *u.m
             #we are at a focus or pupil, so the new optic is the only curvature of the beam
             R_output_beam = -1*optic.fl
             _log.debug(" input flat wavefront and "+ str(optic.name) +" has output beam curvature of ={0:0.2e}".format(R_output_beam))

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -792,7 +792,7 @@ class ParityTestAperture(AnalyticOpticalElement):
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("CircularAperture getPhasor must be called with a Wavefront "
                              "to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         y, x = self.get_coordinates(wave)
         r = np.sqrt(x ** 2 + y ** 2)  #* wave.pixelscale
@@ -853,7 +853,7 @@ class CircularAperture(AnalyticOpticalElement):
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("CircularAperture getPhasor must be called with a Wavefront "
                              "to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         y, x = self.get_coordinates(wave)
         r = np.sqrt(x ** 2 + y ** 2)
@@ -903,7 +903,7 @@ class HexagonAperture(AnalyticOpticalElement):
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("HexagonAperture getPhasor must be called with a Wavefront "
                              "to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         y, x = self.get_coordinates(wave)
         absy = np.abs(y)
@@ -1103,7 +1103,7 @@ class MultiHexagonAperture(AnalyticOpticalElement):
         """
         if not isinstance(wave, Wavefront):
             raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         #y, x = self.get_coordinates(wave)
         #absy = np.abs(y)
@@ -1176,7 +1176,7 @@ class NgonAperture(AnalyticOpticalElement):
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
         y, x = self.get_coordinates(wave)
 
         phase = self.rotation * np.pi / 180
@@ -1226,7 +1226,7 @@ class RectangleAperture(AnalyticOpticalElement):
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
 #        y, x = wave.coordinates()
 #
@@ -1325,7 +1325,7 @@ class SecondaryObscuration(AnalyticOpticalElement):
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         self.transmission = np.ones(wave.shape)
 
@@ -1399,7 +1399,7 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
             raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
-        assert (wave.planetype == _PUPIL)
+        assert (wave.planetype != _IMAGE)
 
         self.transmission = np.ones(wave.shape)
 


### PR DESCRIPTION
In working on test cases, discovered the assertion test in most optics get_phasor prevents you from using them on intermediate wavefronts, to fix changes the test to not apply the optic to an image, rather than requiring a pupil.