### PR TITLE
Allow configurable colormaps and make image origin position consistent

### DIFF
--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -73,7 +73,7 @@ class Conf(_config.ConfigNamespace):
         'verbose printout of fluxes and flux conservation during '+
         'calculations. Useful for testing.')
     cmap_sequential = _config.ConfigItem(
-        'gist_heat',
+        'afmhot',
         'Select a default colormap to represent sequential data (e.g. intensity)'
     )
     cmap_diverging = _config.ConfigItem(

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -3,13 +3,13 @@
 """Physical Optics Propagation in PYthon (POPPY)
 
 
-POPPY is a Python package that simulates physical optical propagation including diffraction. 
+POPPY is a Python package that simulates physical optical propagation including diffraction.
 It implements a flexible framework for modeling Fraunhofer (far-field) diffraction
 and point spread function formation, particularly in the context of astronomical telescopes.
-POPPY was developed as part of a simulation package for JWST, but is more broadly applicable to many kinds of 
-imaging simulations. 
+POPPY was developed as part of a simulation package for JWST, but is more broadly applicable to many kinds of
+imaging simulations.
 
-Developed by Marshall Perrin at STScI, 2010-2014, for use simulating the James Webb Space Telescope. 
+Developed by Marshall Perrin at STScI, 2010-2014, for use simulating the James Webb Space Telescope.
 
 Documentation can be found online at https://pythonhosted.org/poppy/
 
@@ -19,7 +19,7 @@ This is an Astropy affiliated package.
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
-# make use of astropy affiliate framework to set __version__, __githash__, and 
+# make use of astropy affiliate framework to set __version__, __githash__, and
 # add the test() helper function
 from ._astropy_init import *
 # ----------------------------------------------------------------------------
@@ -31,11 +31,11 @@ if _astropy.version.major + _astropy.version.minor*0.1 < 0.4: # pragma: no cover
 
 from astropy import config as _config
 class Conf(_config.ConfigNamespace):
-    """ 
+    """
     Configuration parameters for `poppy`.
     """
 
-    use_multiprocessing = _config.ConfigItem(False, 
+    use_multiprocessing = _config.ConfigItem(False,
             'Should PSF calculations run in parallel using multiple processors'
             'using the Python multiprocessing framework (if True; faster but '
             'does not allow display of each wavelength) or run serially in a '
@@ -72,6 +72,18 @@ class Conf(_config.ConfigNamespace):
     enable_flux_tests =  _config.ConfigItem(False, 'Enable additional '+
         'verbose printout of fluxes and flux conservation during '+
         'calculations. Useful for testing.')
+    cmap_sequential = _config.ConfigItem(
+        'gist_heat',
+        'Select a default colormap to represent sequential data (e.g. intensity)'
+    )
+    cmap_diverging = _config.ConfigItem(
+        'RdBu_r',
+        'Select a default colormap to represent diverging data (e.g. OPD)'
+    )
+    cmap_mask = _config.ConfigItem(
+        'gray',
+        'Select a default colormap to represent 0 or 1 mask data (e.g. aperture masks)'
+    )
 
 conf = Conf()
 
@@ -80,7 +92,7 @@ from . import utils
 from . import optics
 
 from .poppy_core import *
-from .utils import * 
+from .utils import *
 from .optics import *
 from .wfe import *
 

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -80,9 +80,9 @@ class Conf(_config.ConfigNamespace):
         'RdBu_r',
         'Select a default colormap to represent diverging data (e.g. OPD)'
     )
-    cmap_mask = _config.ConfigItem(
+    cmap_pupil_intensity = _config.ConfigItem(
         'gray',
-        'Select a default colormap to represent 0 or 1 mask data (e.g. aperture masks)'
+        'Select a default colormap to represent intensity at pupils or aperture masks'
     )
 
 conf = Conf()

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -73,7 +73,7 @@ class Conf(_config.ConfigNamespace):
         'verbose printout of fluxes and flux conservation during '+
         'calculations. Useful for testing.')
     cmap_sequential = _config.ConfigItem(
-        'afmhot',
+        'gist_heat',
         'Select a default colormap to represent sequential data (e.g. intensity)'
     )
     cmap_diverging = _config.ConfigItem(

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -613,7 +613,7 @@ class AnnularFieldStop(AnalyticOpticalElement):
         self.name = name
         self.radius_inner = radius_inner  # radius of circular occulter in arcseconds.
         self.radius_outer = radius_outer  # radius of circular field stop in arcseconds.
-        self._default_display_size = 10 #radius_outer 
+        self._default_display_size = 10 #radius_outer
 
     def getPhasor(self, wave):
         """ Compute the transmission inside/outside of the field stop.
@@ -823,7 +823,7 @@ class CircularAperture(AnalyticOpticalElement):
     def __init__(self, name=None, radius=1.0, pad_factor=1.0, **kwargs):
         try:
             self.radius = float(radius)
-        except ValueError:
+        except (ValueError, TypeError):
             raise TypeError("Argument 'radius' must be the radius of the pupil in meters")
 
         if name is None:

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -433,24 +433,32 @@ class Wavefront(object):
         if what == 'intensity':
             if self.planetype == _PUPIL:
                 norm = matplotlib.colors.Normalize(vmin=0)
-                cmap = matplotlib.cm.gray
+                cmap = getattr(matplotlib.cm, conf.cmap_mask)
                 cmap.set_bad('0.0')
             else:
                 norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)
-                cmap = matplotlib.cm.jet
+                cmap = getattr(matplotlib.cm, conf.cmap_sequential)
                 cmap.set_bad(cmap(0))
 
             if ax is None:
                 ax = plt.subplot(nr, nc, int(row))
 
-            utils.imshow_with_mouseover(intens, ax=ax, extent=extent, norm=norm, cmap=cmap)
+            utils.imshow_with_mouseover(
+                intens,
+                ax=ax,
+                extent=extent,
+                norm=norm,
+                cmap=cmap,
+                origin='lower'
+            )
             if title is None:
                 title = "Intensity " + self.location
                 title = title.replace('after', 'after\n')
                 title = title.replace('before', 'before\n')
             plt.title(title)
             plt.xlabel(unit)
-            if colorbar: plt.colorbar(ax.images[0], orientation='vertical', shrink=0.8)
+            if colorbar:
+                plt.colorbar(ax.images[0], orientation='vertical', shrink=0.8)
 
             if self.planetype == _IMAGE:
                 if crosshairs:
@@ -463,13 +471,19 @@ class Wavefront(object):
             to_return = ax
         elif what == 'phase':
             # Display phase in waves.
-            cmap = matplotlib.cm.jet
+            cmap = getattr(matplotlib.cm, conf.cmap_diverging)
             cmap.set_bad('0.3')
             norm = matplotlib.colors.Normalize(vmin=-0.25, vmax=0.25)
             if ax is None:
                 ax = plt.subplot(nr, nc, int(row))
-            utils.imshow_with_mouseover(phase / (np.pi * 2), ax=ax, extent=extent, norm=norm,
-                                        cmap=cmap)
+            utils.imshow_with_mouseover(
+                phase / (np.pi * 2),
+                ax=ax,
+                extent=extent,
+                norm=norm,
+                cmap=cmap,
+                origin='lower'
+            )
             if title is None:
                 title = "Phase " + self.location
             plt.title(title)
@@ -481,9 +495,9 @@ class Wavefront(object):
         else:
             if ax is None:
                 ax = plt.subplot(nr, nc, int(row))
-            cmap = matplotlib.cm.gray
+            cmap = getattr(matplotlib.cm, conf.cmap_sequential)
             ax1 = plt.subplot(nrows, 2, (row * 2) - 1)
-            plt.imshow(amp, extent=extent, cmap=cmap)
+            plt.imshow(amp, extent=extent, cmap=cmap, origin='lower')
             plt.title("Wavefront amplitude")
             plt.ylabel(unit)
             plt.xlabel(unit)
@@ -491,7 +505,8 @@ class Wavefront(object):
             if colorbar: plt.colorbar(orientation='vertical', shrink=0.8)
 
             ax2 = plt.subplot(nrows, 2, row * 2)
-            plt.imshow(phase, extent=extent, cmap=cmap)
+            cmap_phase = getattr(matplotlib.cm, conf.cmap_diverging)
+            plt.imshow(phase, extent=extent, cmap=cmap_phase, origin='lower')
             if colorbar: plt.colorbar(orientation='vertical', shrink=0.8)
 
             plt.xlabel(unit)
@@ -1480,7 +1495,8 @@ class OpticalSystem(object):
                 norm=matplotlib.colors.LogNorm(vmin=1e-8,vmax=1e-1)
                 plt.xlabel(unit)
 
-                utils.imshow_with_mouseover(outFITS[0].data, extent=extent, norm=norm, cmap=cmap)
+                utils.imshow_with_mouseover(outFITS[0].data, extent=extent, norm=norm, cmap=cmap,
+                                            origin='lower')
 
         if save_intermediates:
             _log.info('Saving intermediate wavefronts:')
@@ -1904,9 +1920,12 @@ class OpticalElement(object):
         if colorbar_orientation is None:
             colorbar_orientation = "horizontal" if nrows == 1 else 'vertical'
 
-        cmap_amp = matplotlib.cm.gray
+        if self.planetype is _PUPIL:
+            cmap_amp = getattr(matplotlib.cm, conf.cmap_mask)
+        else:
+            cmap_amp = getattr(matplotlib.cm, conf.cmap_sequential)
         cmap_amp.set_bad('0.0')
-        cmap_opd = matplotlib.cm.jet
+        cmap_opd = getattr(matplotlib.cm, conf.cmap_diverging)
         cmap_opd.set_bad('0.3')
         norm_amp = matplotlib.colors.Normalize(vmin=0, vmax=1)
         norm_opd = matplotlib.colors.Normalize(vmin=-opd_vmax, vmax=opd_vmax)
@@ -1965,7 +1984,8 @@ class OpticalElement(object):
                 ax = plt.subplot(nrows, 2, row * 2 - 1)
             else:
                 ax = plt.subplot(111)
-        utils.imshow_with_mouseover(plot_array, ax=ax, extent=extent, cmap=cmap, norm=norm)
+        utils.imshow_with_mouseover(plot_array, ax=ax, extent=extent, cmap=cmap, norm=norm,
+                                    origin='lower')
         if nrows == 1:
             plt.title(title + " for " + self.name)
         plt.ylabel(units)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1951,11 +1951,13 @@ class OpticalElement(object):
             if ax is None:
                 ax = plt.subplot(nrows, 2, row * 2 - 1)
             self.display(what='intensity', ax=ax, crosshairs=crosshairs, colorbar=colorbar,
+                         colorbar_orientation=colorbar_orientation, title=None, opd_vmax=opd_vmax,
                          nrows=nrows)
             ax2 = plt.subplot(nrows, 2, row * 2)
             self.display(what='phase', ax=ax2, crosshairs=crosshairs, colorbar=colorbar,
+                         colorbar_orientation=colorbar_orientation, title=None, opd_vmax=opd_vmax,
                          nrows=nrows)
-            return (ax, ax2)
+            return ax, ax2
         elif what == 'amplitude':
             plot_array = ampl
             title = 'Transmissivity'

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -433,7 +433,7 @@ class Wavefront(object):
         if what == 'intensity':
             if self.planetype == _PUPIL:
                 norm = matplotlib.colors.Normalize(vmin=0)
-                cmap = getattr(matplotlib.cm, conf.cmap_mask)
+                cmap = getattr(matplotlib.cm, conf.cmap_pupil_intensity)
                 cmap.set_bad('0.0')
             else:
                 norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)
@@ -1921,7 +1921,7 @@ class OpticalElement(object):
             colorbar_orientation = "horizontal" if nrows == 1 else 'vertical'
 
         if self.planetype is _PUPIL:
-            cmap_amp = getattr(matplotlib.cm, conf.cmap_mask)
+            cmap_amp = getattr(matplotlib.cm, conf.cmap_pupil_intensity)
         else:
             cmap_amp = getattr(matplotlib.cm, conf.cmap_sequential)
         cmap_amp.set_bad('0.0')

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1485,7 +1485,7 @@ class OpticalSystem(object):
 
             if display:
                 # Add final intensity panel to intermediate WF plot
-                cmap = matplotlib.cm.jet
+                cmap = getattr(matplotlib.cm, conf.cmap_sequential)
                 cmap.set_bad('0.3')
                 #cmap.set_bad('k', 0.8)
                 halffov_x =outFITS[0].header['PIXELSCL']*outFITS[0].data.shape[1]/2

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -324,27 +324,30 @@ class Wavefront(object):
         self.asFITS(**kwargs).writeto(filename, clobber=clobber)
         _log.info("  Wavefront saved to %s" % filename)
 
-    def display(self,what='intensity', nrows=1,row=1,showpadding=False,imagecrop=None, colorbar=False, crosshairs=True, ax=None, title=None,vmin=1e-8,vmax=1e0):
+    def display(self, what='intensity', nrows=1, row=1, showpadding=False, imagecrop=None,
+                colorbar=False, crosshairs=True, ax=None, title=None, vmin=1e-8, vmax=1e0):
         """Display wavefront on screen
 
         Parameters
         ----------
         what : string
            What to display. Must be one of {intensity, phase, best}.
-           'Best' implies to display the phase if there is nonzero OPD, or else
-           display the intensity for a perfect pupil.
-
+           'Best' implies to display the phase if there is nonzero OPD,
+           or else display the intensity for a perfect pupil.
         nrows : int
-            Number of rows to display in current figure (used for showing steps in a calculation)
+            Number of rows to display in current figure (used for
+            showing steps in a calculation)
         row : int
             Which row to display this one in?
         imagecrop : float, optional
-            For image planes, set the maximum # of arcseconds to display. Default is 5, so
-            only the innermost 5x5 arcsecond region will be shown. This default may be
-            changed in the POPPY config file. If the image size is < 5 arcsec then the
+            For image planes, set the maximum # of arcseconds to
+            display. Default is 5, so only the innermost 5x5 arcsecond
+            region will be shown. This default may be changed in the
+            POPPY config file. If the image size is < 5 arcsec then the
             entire image is displayed.
         showpadding : bool, optional
-            Show the entire padded arrays, or just the good parts? Default is False
+            Show the entire padded arrays, or just the good parts?
+            Default is False
         colorbar : bool
             Display colorbar
         ax : matplotlib Axes
@@ -354,112 +357,121 @@ class Wavefront(object):
         -------
         figure : matplotlib figure
             The current figure is modified.
-
-
         """
-        if imagecrop is None: imagecrop = conf.default_image_display_fov
+        if imagecrop is None:
+            imagecrop = conf.default_image_display_fov
 
         intens = self.intensity.copy()
-        phase  = self.phase.copy()
-        phase[np.where(intens ==0)] = np.nan
-        amp    = self.amplitude
+        phase = self.phase.copy()
+        phase[np.where(intens == 0)] = np.nan
+        amp = self.amplitude
 
-        if self.planetype==_PUPIL and self.ispadded and not showpadding :
-            intens = utils.removePadding(intens,self.oversample)
-            phase = utils.removePadding(phase,self.oversample)
-            amp = utils.removePadding(amp,self.oversample)
+        if self.planetype == _PUPIL and self.ispadded and not showpadding:
+            intens = utils.removePadding(intens, self.oversample)
+            phase = utils.removePadding(phase, self.oversample)
+            amp = utils.removePadding(amp, self.oversample)
 
-
-        # extent specifications need to include the *full* data region, including the half pixel on either
-        # side outside of the pixel center coordinates.  And remember to swap Y and X.  Recall that for matplotlib,
+        # extent specifications need to include the *full* data region, including the half pixel
+        # on either side outside of the pixel center coordinates.  And remember to swap Y and X.
+        # Recall that for matplotlib,
         #    extent = [xmin, xmax, ymin, ymax]
-        # in this case those are coordinates in units of pixels. Recall that we define pixel coordinates to be
-        # at the *center* of the pixel, so we compute here the coordinates at the outside of those pixels.
+        # in this case those are coordinates in units of pixels. Recall that we define pixel
+        # coordinates to be at the *center* of the pixel, so we compute here the coordinates at the
+        # outside of those pixels.
         # This is needed to get the coordinates right when displaying very small arrays
 
-        extent = np.array([-0.5 ,intens.shape[1]-1+0.5, -0.5,intens.shape[0]-1+0.5]) * self.pixelscale
+        extent = self.pixelscale * np.array([
+                -0.5,
+                intens.shape[1] - 1 + 0.5,
+                -0.5,
+                intens.shape[0] - 1 + 0.5
+        ])
         if self.planetype == _PUPIL:
-            # For pupils, we just let the 0 point be that of the array, off to the side of the actual clear aperture
+            # For pupils, we just let the 0 point be that of the array, off to the side of the
+            # actual clear aperture
             # No - now let's be consistent with how OpticalElement.display() works
-            cenx = (intens.shape[1]-1)/2.
-            ceny = (intens.shape[0]-1)/2.
-            extent -= np.asarray([cenx, cenx, ceny, ceny])*self.pixelscale
+            cenx = (intens.shape[1] - 1) / 2.
+            ceny = (intens.shape[0] - 1) / 2.
+            extent -= np.asarray([cenx, cenx, ceny, ceny]) * self.pixelscale
 
             unit = "m"
         else:
             # for image planes, we make coordinates relative to center.
             # image plane coordinates depend slightly on whether the optical center is at a
             # pixel-center or the corner between 4 pixels...
-            if self._image_centered == 'array_center' or self._image_centered=='corner':
-                cenx = (intens.shape[1]-1)/2.
-                ceny = (intens.shape[0]-1)/2.
+            if self._image_centered == 'array_center' or self._image_centered == 'corner':
+                cenx = (intens.shape[1] - 1) / 2.
+                ceny = (intens.shape[0] - 1) / 2.
             elif self._image_centered == 'pixel':
-                cenx = (intens.shape[1])/2.
-                ceny = (intens.shape[0])/2.
+                cenx = (intens.shape[1]) / 2.
+                ceny = (intens.shape[0]) / 2.
 
-            extent -= np.asarray([cenx, cenx, ceny, ceny])*self.pixelscale
-            halffov_x = intens.shape[1]/2.*self.pixelscale #for use later
-            halffov_y = intens.shape[0]/2.*self.pixelscale #for use later
-            unit="arcsec"
+            extent -= self.pixelscale * np.asarray([cenx, cenx, ceny, ceny])
+            halffov_x = intens.shape[1] / 2. * self.pixelscale  # for use later
+            halffov_y = intens.shape[0] / 2. * self.pixelscale  # for use later
+            unit = "arcsec"
 
         # implement semi-intellegent selection of what to display, if the user wants
-        if what =='best':
-            if self.planetype ==_IMAGE:
-                what = 'intensity' # always show intensity for image planes
+        if what == 'best':
+            if self.planetype == _IMAGE:
+                what = 'intensity'  # always show intensity for image planes
             elif phase[np.where(np.isfinite(phase))].sum() == 0:
-                what = 'intensity' # for perfect pupils
-            elif int(row) > 2: what='intensity'  # show intensity for coronagraphic downstream propagation.
-            else: what='phase' # for aberrated pupils
+                what = 'intensity'  # for perfect pupils
+            elif int(row) > 2:
+                what = 'intensity'  # show intensity for coronagraphic downstream propagation.
+            else:
+                what = 'phase'  # for aberrated pupils
 
         # compute plot parameters for the subplot grid
         nc = int(np.ceil(np.sqrt(nrows)))
-        nr = int(np.ceil(float(nrows)/nc))
-        if (nrows - nc*(nc-1) == 1) and (nr>1): # avoid just one alone on a row by itself...
+        nr = int(np.ceil(float(nrows) / nc))
+        if (nrows - nc * (nc - 1) == 1) and (nr > 1):  # avoid just one alone on a row by itself...
             nr -= 1
             nc += 1
 
         # now display the chosen selection..
         if what == 'intensity':
             if self.planetype == _PUPIL:
-                norm=matplotlib.colors.Normalize(vmin=0)
+                norm = matplotlib.colors.Normalize(vmin=0)
                 cmap = matplotlib.cm.gray
                 cmap.set_bad('0.0')
             else:
-                norm=matplotlib.colors.LogNorm(vmin=vmin,vmax=vmax)
+                norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)
                 cmap = matplotlib.cm.jet
                 cmap.set_bad(cmap(0))
 
             if ax is None:
-                ax = plt.subplot(nr,nc,int(row))
+                ax = plt.subplot(nr, nc, int(row))
 
             utils.imshow_with_mouseover(intens, ax=ax, extent=extent, norm=norm, cmap=cmap)
             if title is None:
-                title = "Intensity "+self.location
+                title = "Intensity " + self.location
                 title = title.replace('after', 'after\n')
                 title = title.replace('before', 'before\n')
             plt.title(title)
             plt.xlabel(unit)
             if colorbar: plt.colorbar(ax.images[0], orientation='vertical', shrink=0.8)
 
-            if self.planetype ==_IMAGE:
+            if self.planetype == _IMAGE:
                 if crosshairs:
-                    plt.axhline(0,ls=":", color='k')
-                    plt.axvline(0,ls=":", color='k')
-                imsize_x = min( (imagecrop, halffov_x))
-                imsize_y = min( (imagecrop, halffov_y))
+                    plt.axhline(0, ls=":", color='k')
+                    plt.axvline(0, ls=":", color='k')
+                imsize_x = min((imagecrop, halffov_x))
+                imsize_y = min((imagecrop, halffov_y))
                 ax.set_xbound(-imsize_x, imsize_x)
                 ax.set_ybound(-imsize_y, imsize_y)
             to_return = ax
-        elif what =='phase':
+        elif what == 'phase':
             # Display phase in waves.
             cmap = matplotlib.cm.jet
             cmap.set_bad('0.3')
-            norm=matplotlib.colors.Normalize(vmin=-0.25,vmax=0.25)
+            norm = matplotlib.colors.Normalize(vmin=-0.25, vmax=0.25)
             if ax is None:
-                ax = plt.subplot(nr,nc,int(row))
-            utils.imshow_with_mouseover(phase/(np.pi*2), ax=ax, extent=extent, norm=norm, cmap=cmap)
+                ax = plt.subplot(nr, nc, int(row))
+            utils.imshow_with_mouseover(phase / (np.pi * 2), ax=ax, extent=extent, norm=norm,
+                                        cmap=cmap)
             if title is None:
-                title= "Phase "+self.location
+                title = "Phase " + self.location
             plt.title(title)
             plt.xlabel(unit)
             if colorbar: plt.colorbar(ax.images[0], orientation='vertical', shrink=0.8)
@@ -468,28 +480,27 @@ class Wavefront(object):
 
         else:
             if ax is None:
-                ax = plt.subplot(nr,nc,int(row))
+                ax = plt.subplot(nr, nc, int(row))
             cmap = matplotlib.cm.gray
-            ax1 = plt.subplot(nrows,2,(row*2)-1)
-            plt.imshow(amp,extent=extent,cmap=cmap)
+            ax1 = plt.subplot(nrows, 2, (row * 2) - 1)
+            plt.imshow(amp, extent=extent, cmap=cmap)
             plt.title("Wavefront amplitude")
             plt.ylabel(unit)
             plt.xlabel(unit)
 
-            if colorbar: plt.colorbar(orientation='vertical',shrink=0.8)
+            if colorbar: plt.colorbar(orientation='vertical', shrink=0.8)
 
-            ax2 = plt.subplot(nrows,2,row*2)
-            plt.imshow(phase,extent=extent, cmap=cmap)
-            if colorbar: plt.colorbar(orientation='vertical',shrink=0.8)
+            ax2 = plt.subplot(nrows, 2, row * 2)
+            plt.imshow(phase, extent=extent, cmap=cmap)
+            if colorbar: plt.colorbar(orientation='vertical', shrink=0.8)
 
             plt.xlabel(unit)
             plt.title("Wavefront phase [radians]")
 
-            to_return = (ax1,ax2)
+            to_return = (ax1, ax2)
 
         ax.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(5))
         ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(5))
-
 
         plt.draw()
         return to_return
@@ -1373,7 +1384,7 @@ class OpticalSystem(object):
             utils.fftw_load_wisdom()
 
         if conf.use_multiprocessing and len(wavelength) > 1: ######### Parallellized computation ############
-            # Avoid a Mac OS incompatibility that can lead to hard-to-reproduce crashes. 
+            # Avoid a Mac OS incompatibility that can lead to hard-to-reproduce crashes.
             import sys
             import platform
             if ( (sys.version_info < (3,4,0)) and platform.system()=='Darwin' and
@@ -1407,7 +1418,7 @@ class OpticalSystem(object):
             if ((sys.version_info.major+sys.version_info.minor*0.1) < 3.4):
                 pool = multiprocessing.Pool(int(nproc))
             else:
-                # Use new forkserver for more robustness; 
+                # Use new forkserver for more robustness;
                 # Resolves https://github.com/mperrin/poppy/issues/23 ?
                 ctx = multiprocessing.get_context('forkserver')
                 pool =ctx.Pool(int(nproc))
@@ -1865,17 +1876,19 @@ class OpticalElement(object):
         else:
             return self.phasor
 
-    def display(self, nrows=1, row=1, what='intensity', crosshairs=True, ax=None, colorbar=True, colorbar_orientation=None, title=None, opd_vmax=0.5e-6):
+    def display(self, nrows=1, row=1, what='intensity', crosshairs=True, ax=None, colorbar=True,
+                colorbar_orientation=None, title=None, opd_vmax=0.5e-6):
         """Display plots showing an optic's transmission and OPD.
 
         Parameters
         ----------
         what : str
-            What to display: 'intensity', 'amplitude', 'phase', or 'both' (meaning intensity + phase)
+            What to display: 'intensity', 'amplitude', 'phase',
+            or 'both' (meaning intensity and phase in two subplots)
         ax : matplotlib.Axes instance
             Axes to display into
         nrows, row : integers
-            # of rows and row index for subplot display
+            number of rows and row index for subplot display
         crosshairs : bool
             Display crosshairs indicating the center?
         colorbar : bool
@@ -1884,80 +1897,77 @@ class OpticalElement(object):
             Desired orientation, horizontal or vertical?
             Default is horizontal if only 1 row of plots, else vertical
         opd_vmax : float
-            Max value for OPD image display, in meters.
+            Max absolute value for OPD image display, in meters.
         title : string
             Plot label
-
-
         """
         if colorbar_orientation is None:
-            colorbar_orientation= "horizontal" if nrows == 1 else 'vertical'
+            colorbar_orientation = "horizontal" if nrows == 1 else 'vertical'
 
-        _log.debug('colorbar_orientation = '+colorbar_orientation)
         cmap_amp = matplotlib.cm.gray
         cmap_amp.set_bad('0.0')
         cmap_opd = matplotlib.cm.jet
         cmap_opd.set_bad('0.3')
-        norm_amp=matplotlib.colors.Normalize(vmin=0, vmax=1)
-        norm_opd=matplotlib.colors.Normalize(vmin=-opd_vmax, vmax=opd_vmax)
+        norm_amp = matplotlib.colors.Normalize(vmin=0, vmax=1)
+        norm_opd = matplotlib.colors.Normalize(vmin=-opd_vmax, vmax=opd_vmax)
 
         units = "[meters]" if self.planetype == _PUPIL else "[arcsec]"
-        if nrows > 1: units = self.name+"\n"+units
-
+        if nrows > 1:
+            units = self.name + "\n" + units
 
         if self.pixelscale is not None:
-            halfsize = self.pixelscale*self.amplitude.shape[0]/2
+            halfsize = self.pixelscale * self.amplitude.shape[0] / 2
             _log.debug("Display pixel scale = %.3f " % self.pixelscale)
         else:
             _log.debug("No defined pixel scale - this must be an analytic optic")
-            halfsize=1.0
+            halfsize = 1.0
         extent = [-halfsize, halfsize, -halfsize, halfsize]
 
-
-        #ampl = np.ma.masked_equal(self.amplitude, 0)
         ampl = self.amplitude
-        #opd= np.ma.masked_array(self.opd, mask=(self.amplitude ==0))
         opd = self.opd.copy()
-        opd[np.where(self.amplitude ==0)] = np.nan
+        opd[np.where(self.amplitude == 0)] = np.nan
 
-        if what =='both':
+        if what == 'both':
             # recursion!
             if ax is None:
-                ax = plt.subplot(nrows, 2, row*2-1)
-            self.display(what='intensity', ax=ax, crosshairs=crosshairs, colorbar=colorbar, nrows=nrows)
-            ax2 = plt.subplot(nrows, 2, row*2)
-            self.display(what='phase', ax=ax2, crosshairs=crosshairs, colorbar=colorbar, nrows=nrows)
-            return (ax,ax2)
-        elif what=='amplitude':
+                ax = plt.subplot(nrows, 2, row * 2 - 1)
+            self.display(what='intensity', ax=ax, crosshairs=crosshairs, colorbar=colorbar,
+                         nrows=nrows)
+            ax2 = plt.subplot(nrows, 2, row * 2)
+            self.display(what='phase', ax=ax2, crosshairs=crosshairs, colorbar=colorbar,
+                         nrows=nrows)
+            return (ax, ax2)
+        elif what == 'amplitude':
             plot_array = ampl
             title = 'Transmissivity'
             cb_label = 'Fraction'
-            cb_values = [0,0.25, 0.5, 0.75, 1.0]
+            cb_values = [0, 0.25, 0.5, 0.75, 1.0]
             cmap = cmap_amp
             norm = norm_amp
-        elif what=='intensity':
-            plot_array = ampl**2
+        elif what == 'intensity':
+            plot_array = ampl ** 2
             title = "Transmittance"
             cb_label = 'Fraction'
-            cb_values = [0,0.25, 0.5, 0.75, 1.0]
+            cb_values = [0, 0.25, 0.5, 0.75, 1.0]
             cmap = cmap_amp
             norm = norm_amp
-        elif what =='phase':
+        elif what == 'phase':
             plot_array = opd
             title = "OPD"
             cb_label = 'meters'
-            cb_values = np.array([-1, -0.5, 0, 0.5, 1])*opd_vmax
+            cb_values = np.array([-1, -0.5, 0, 0.5, 1]) * opd_vmax
             cmap = cmap_opd
             norm = norm_opd
 
         # now we plot whichever was chosen...
         if ax is None:
             if nrows > 1:
-                ax = plt.subplot(nrows, 2, row*2-1)
-            else: ax = plt.subplot(111)
+                ax = plt.subplot(nrows, 2, row * 2 - 1)
+            else:
+                ax = plt.subplot(111)
         utils.imshow_with_mouseover(plot_array, ax=ax, extent=extent, cmap=cmap, norm=norm)
         if nrows == 1:
-            plt.title(title+" for "+self.name)
+            plt.title(title + " for " + self.name)
         plt.ylabel(units)
         ax.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))
         ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))
@@ -1965,8 +1975,8 @@ class OpticalElement(object):
             cb = plt.colorbar(ax.images[0], orientation=colorbar_orientation, ticks=cb_values)
             cb.set_label(cb_label)
         if crosshairs:
-            ax.axhline(0,ls=":", color='k')
-            ax.axvline(0,ls=":", color='k')
+            ax.axhline(0, ls=":", color='k')
+            ax.axvline(0, ls=":", color='k')
         return ax
 
     def __str__(self):

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 import scipy.interpolate, scipy.ndimage
 import matplotlib
 import logging
+import poppy
 _log = logging.getLogger('poppy')
 import astropy.io.fits as fits
 
@@ -31,8 +32,7 @@ __all__ = [ 'display_PSF', 'display_PSF_difference', 'display_EE', 'display_prof
 
 def imshow_with_mouseover(image, ax=None,  *args, **kwargs):
     """Wrapper for matplotlib imshow that displays the value under the
-    cursor position and defaults to placing the image origin
-    (pixel 0, 0) at the lower left corner of the plot
+    cursor position
 
     Wrapper for pyplot.imshow that sets up a custom mouseover display
     formatter so that mouse motions over the image are labeled in the
@@ -40,9 +40,6 @@ def imshow_with_mouseover(image, ax=None,  *args, **kwargs):
     """
     if ax is None:
         ax = plt.gca()
-    if 'origin' not in kwargs:
-        # default to placing pixel (0, 0) at lower left unless specified otherwise
-        kwargs['origin'] = 'lower'
     myax = ax.imshow(image, *args, **kwargs)
     aximage = ax.images[0].properties()['array']
     # need to account for half pixel offset of array coordinates for mouseover relative to pixel center,
@@ -73,7 +70,7 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
                 adjust_for_oversampling=False, normalize='None',
                 crosshairs=False, markcentroid=False, colorbar=True,
                 colorbar_orientation='vertical', pixelscale='PIXELSCL',
-                ax=None, return_ax=False):
+                ax=None, return_ax=False, interpolation='nearest'):
     """Display nicely a PSF from a given HDUlist or filename
 
     This is extensively configurable. In addition to making an attractive display, for
@@ -92,25 +89,24 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
         'linear' or 'log', default is log
     cmap : matplotlib.cm.Colormap instance or None
         Colormap to use. If not given, taken from user's
-        `matplotlib.rcParams['image.cmap']` (or matplotlib's default).
-    ax : matplotlib.Axes instance
-        Axes to display into.
-    return_ax : bool
-        Return the axes to the caller for later use? (Default: False)
-        When True, this function returns a matplotlib.Axes instance, or a
-        tuple of (ax, cb) where the second is the colorbar Axes.
+        `poppy.conf.cmap_sequential` (Default: 'gist_heat').
     title : string, optional
+        Set the plot title explicitly.
     imagecrop : float
         size of region to display (default is whole image)
-    normalize : string
-        set to 'peak' to normalize peak intensity =1, or to 'total' to normalize total flux=1. Default is no normalization.
     adjust_for_oversampling : bool
         rescale to conserve surface brightness for oversampled PSFs?
-        (making this True conserves surface brightness but not total flux)
-        default is False, to conserve total flux.
+        (Making this True conserves surface brightness but not
+        total flux.) Default is False, to conserve total flux.
+    normalize : string
+        set to 'peak' to normalize peak intensity =1, or to 'total' to
+        normalize total flux=1. Default is no normalization.
+    crosshairs : bool
+        Draw a crosshairs at the image center (0, 0)? Default: False.
     markcentroid : bool
         Draw a crosshairs at the image centroid location?
-        Centroiding is computed with the JWST-standard moving box algorithm.
+        Centroiding is computed with the JWST-standard moving box
+        algorithm. Default: False.
     colorbar : bool
         Draw a colorbar on the image?
     colorbar_orientation : 'vertical' (default) or 'horizontal'
@@ -120,6 +116,16 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
     pixelscale : str or float
         if str, interpreted as the FITS keyword name for the pixel scale in arcsec/pixels.
         if float, used as the pixelscale directly.
+    ax : matplotlib.Axes instance
+        Axes to display into.
+    return_ax : bool
+        Return the axes to the caller for later use? (Default: False)
+        When True, this function returns a matplotlib.Axes instance, or a
+        tuple of (ax, cb) where the second is the colorbar Axes.
+    interpolation : string
+        Interpolation technique for PSF image. Default is None,
+        meaning it is taken from matplotlib's `image.interpolation`
+        rcParam.
     """
     if isinstance(HDUlist_or_filename, six.string_types):
         HDUlist = fits.open(HDUlist_or_filename)
@@ -164,8 +170,18 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
     unit = "arcsec"
     extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
 
+    if cmap is None:
+        cmap = getattr(matplotlib.cm, poppy.conf.cmap_sequential)
     # update and get (or create) image axes
-    ax = imshow_with_mouseover(im, extent=extent, cmap=cmap, norm=norm, ax=ax)
+    ax = imshow_with_mouseover(
+        im,
+        extent=extent,
+        cmap=cmap,
+        norm=norm,
+        ax=ax,
+        interpolation=interpolation,
+        origin='lower'
+    )
     if imagecrop is not None:
         halffov_x = min((imagecrop / 2.0, halffov_x))
         halffov_y = min((imagecrop / 2.0, halffov_y))
@@ -326,7 +342,8 @@ def display_PSF_difference(HDUlist_or_filename1=None, HDUlist_or_filename2=None,
     extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
 
 
-    ax = imshow_with_mouseover( diff_im   ,extent=extent,cmap=cmap, norm=norm, ax=ax)
+    ax = imshow_with_mouseover(diff_im, extent=extent,cmap=cmap, norm=norm, ax=ax,
+                               origin='lower')
     if imagecrop is not None:
         halffov_x = min( (imagecrop/2, halffov_x))
         halffov_y = min( (imagecrop/2, halffov_y))
@@ -415,7 +432,7 @@ def display_profiles(HDUlist_or_filename=None,ext=0, overplot=False, title=None,
         whether to overplot or clear and produce an new plot. Default false
     title : string, optional
         Title for plot
- 
+
     """
     if isinstance(HDUlist_or_filename, six.string_types):
         HDUlist = fits.open(HDUlist_or_filename,ext=ext)

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -30,16 +30,19 @@ __all__ = [ 'display_PSF', 'display_PSF_difference', 'display_EE', 'display_prof
 
 
 def imshow_with_mouseover(image, ax=None,  *args, **kwargs):
-    """ wrapper for matplotlib imshow that displays the value under the cursor position
+    """Wrapper for matplotlib imshow that displays the value under the
+    cursor position and defaults to placing the image origin
+    (pixel 0, 0) at the lower left corner of the plot
 
-    Wrapper for pyplot.imshow that sets up a custom mouseover display formatter
-    so that mouse motions over the image are labeled in the status bar with
-    pixel numerical value as well as X and Y coords.
-
-    Why this behavior isn't the matplotlib default, I have no idea...
+    Wrapper for pyplot.imshow that sets up a custom mouseover display
+    formatter so that mouse motions over the image are labeled in the
+    status bar with pixel numerical value as well as X and Y coords.
     """
     if ax is None:
         ax = plt.gca()
+    if 'origin' not in kwargs:
+        # default to placing pixel (0, 0) at lower left unless specified otherwise
+        kwargs['origin'] = 'lower'
     myax = ax.imshow(image, *args, **kwargs)
     aximage = ax.images[0].properties()['array']
     # need to account for half pixel offset of array coordinates for mouseover relative to pixel center,

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -70,7 +70,7 @@ def display_PSF(HDUlist_or_filename, ext=0, vmin=1e-8, vmax=1e-1,
                 adjust_for_oversampling=False, normalize='None',
                 crosshairs=False, markcentroid=False, colorbar=True,
                 colorbar_orientation='vertical', pixelscale='PIXELSCL',
-                ax=None, return_ax=False, interpolation='nearest'):
+                ax=None, return_ax=False, interpolation=None):
     """Display nicely a PSF from a given HDUlist or filename
 
     This is extensively configurable. In addition to making an attractive display, for

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -440,7 +440,7 @@ def display_profiles(HDUlist_or_filename=None,ext=0, overplot=False, title=None,
         HDUlist = HDUlist_or_filename
     else: raise ValueError("input must be a filename or HDUlist")
 
-    radius, profile, EE = radial_profile(HDUlist, EE=True, **kwargs)
+    radius, profile, EE = radial_profile(HDUlist, EE=True, ext=ext, **kwargs)
 
     if title is None:
         try:


### PR DESCRIPTION
In order to let us say things about orientation of features in POPPY images and be understood across different possible user configurations, we need to specify `origin='lower'` every time we plot an image. (We could alternatively change every call to `imshow` to use a wrapper in POPPY, or use matplotlib's context manager to swap in our rcParams values.)

Also, this might be a good time to use more-highly-recommended colormaps. I added config options for `cmap_sequential`, `cmap_diverging`, and `cmap_mask`; defaulting to `afmhot`, `RdBu_r` (reversed so higher values are red, lower are blue), and `gray` respectively.

## [**The old origin and cmap behavior** (notebook)](http://nbviewer.ipython.org/gist/josePhoenix/8d01c37e9c491b8c2c32)

Example:

![old_cmap](https://cloud.githubusercontent.com/assets/172886/10503617/cf31d9ec-72c5-11e5-86a6-aff06c7da572.png)

## [**The new behavior** (notebook)](http://nbviewer.ipython.org/gist/josePhoenix/fe39f5451f2eb801c82c)

Example:

![new_cmap](https://cloud.githubusercontent.com/assets/172886/10503715/d677bd06-72c6-11e5-8315-6b7dd9a83387.png)

