### PR TITLE
Skip test_optic_resizing on Travis-CI

### DIFF
--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -1,11 +1,16 @@
-#Test functions for core poppy functionality
-
-from .. import poppy_core 
-from .. import optics
+# Test functions for core poppy functionality
+import os
 
 import numpy as np
-import astropy.io.fits as fits
+from astropy.io import fits
+import pytest
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
+from .. import poppy_core
+from .. import optics
 
 ####### Test Common Infrastructre #######
 
@@ -319,14 +324,14 @@ def test_inverse_MFT():
     assert(   np.abs(psf1[0].data - psf[0].data).max()  < 1e-7 )
 
 
-import pytest
-
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(
+    (scipy is None),
+    reason='No SciPy installed'
+)
+@pytest.mark.skipif(
+    (os.environ.get('TRAVIS') == 'true'),
+    reason='Memory usage too high for Travis'
+)
 def test_optic_resizing():
     '''
     Tests the rescaling functionality of OpticalElement.getPhasor(),
@@ -347,4 +352,3 @@ def test_optic_resizing():
     osys.addPupil(optics.CircularAperture(radius=3.25))
     assert(test_optic_small_element.getPhasor(osys.inputWavefront()).shape ==osys.inputWavefront().shape )
     assert(test_optic_large_element.getPhasor(osys.inputWavefront()).shape ==osys.inputWavefront().shape )
-


### PR DESCRIPTION
I'm curious to see if this passes. I'm opening a PR so it'll run with the upstream `.travis.yml` instead of the one in my fork.