### PR TITLE
Better rescaling test

### DIFF
--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -857,7 +857,7 @@ class HexagonAperture(AnalyticOpticalElement):
     """ Defines an ideal hexagonal pupil aperture
 
     Specify either the side length (= corner radius) or the
-    flat-to-flat distance.
+    flat-to-flat distance, or the point-to-point diameter.
 
     Parameters
     ----------
@@ -867,20 +867,36 @@ class HexagonAperture(AnalyticOpticalElement):
         side length (and/or radius) of hexagon, in meters. Overrides flattoflat if both are present.
     flattoflat : float, optional
         Distance between sides (flat-to-flat) of the hexagon, in meters. Default is 1.0
+    diameter : float, optional
+        point-to-point diameter of hexagon. Twice the side length. Overrides flattoflat, but is overridden by side. 
+
     """
 
-    def __init__(self, name=None, flattoflat=None, side=None, **kwargs):
-        if flattoflat is None and side is None:
+    def __init__(self, name=None, side=None, diameter=None, flattoflat=None, **kwargs):
+        if flattoflat is None and side is None and diameter is None:
             self.side = 1.0
         elif side is not None:
             self.side = float(side)
+        elif diameter is not None:
+            self.side = float(diameter/2)
         else:
             self.side = float(flattoflat) / np.sqrt(3.)
+
+
         self.pupil_diam = 2 * self.side  # for creating input wavefronts
         if name is None:
             name = "Hexagon, side length= %.1f m" % self.side
 
         AnalyticOpticalElement.__init__(self, name=name, planetype=_PUPIL, **kwargs)
+
+
+    @property
+    def diameter(self):
+        return self.side*2
+
+    @property
+    def flat_to_flat(self):
+        return self.side*np.sqrt(3.)
 
 
     def getPhasor(self, wave):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1849,6 +1849,7 @@ class OpticalElement(object):
                 resampled_opd = scipy.ndimage.interpolation.zoom(self.opd,zoom,output=self.opd.dtype,order=self.interp_order)
                 resampled_amplitude = scipy.ndimage.interpolation.zoom(self.amplitude,zoom,output=self.amplitude.dtype,order=self.interp_order)
                 _log.debug("resampled optic to match wavefront via spline interpolation by a zoom factor of %.3g"%(zoom))
+                _log.debug("resampled optic shape: {}   wavefront shape: {}".format(resampled_amplitude.shape, wave.shape))
 
                 lx,ly=resampled_amplitude.shape
                 #crop down to match size of wavefront:

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -339,16 +339,32 @@ def test_optic_resizing():
     creating an optic with a large pixel scale, and checking the returned
     phasor of each has the dimensions of the input wavefront.
     '''
-    osys = poppy_core.OpticalSystem("test", oversample=1)
+
+    # diameter 1 meter, pixel scale 2 mm
+    inputwf = poppy_core.Wavefront(diam=1.0, npix=500)
+
+    # Test rescaling from finer scales: diameter 1 meter, pixel scale 1 mm 
     test_optic_small=fits.HDUList([fits.PrimaryHDU(np.zeros([1000,1000]))])
-    test_optic_small[0].header["PIXSCALE"]=.001
-
+    test_optic_small[0].header["PUPLSCAL"]=.001
     test_optic_small_element=poppy_core.FITSOpticalElement(transmission=test_optic_small)
+    assert(test_optic_small_element.getPhasor(inputwf).shape ==inputwf.shape )
 
-    test_optic_large=fits.HDUList([fits.PrimaryHDU(np.zeros([1000,1000]))])
-    test_optic_large[0].header["PIXSCALE"]=.1
+    # Test rescaling from coarser scales: diameter 1 meter, pixel scale 10 mm
+    test_optic_large=fits.HDUList([fits.PrimaryHDU(np.zeros([100,100]))])
+    test_optic_large[0].header["PUPLSCAL"]=.01
     test_optic_large_element=poppy_core.FITSOpticalElement(transmission=test_optic_large)
+    assert(test_optic_large_element.getPhasor(inputwf).shape ==inputwf.shape )
 
-    osys.addPupil(optics.CircularAperture(radius=3.25))
-    assert(test_optic_small_element.getPhasor(osys.inputWavefront()).shape ==osys.inputWavefront().shape )
-    assert(test_optic_large_element.getPhasor(osys.inputWavefront()).shape ==osys.inputWavefront().shape )
+    # Test rescaling where we have to pad with extra zeros: 
+    # diameter 0.8 mm, pixel scale 1 mm
+    test_optic_pad=fits.HDUList([fits.PrimaryHDU(np.zeros([800,800]))])
+    test_optic_pad[0].header["PUPLSCAL"]=.001
+    test_optic_pad_element=poppy_core.FITSOpticalElement(transmission=test_optic_pad)
+    assert(test_optic_pad_element.getPhasor(inputwf).shape ==inputwf.shape )
+
+    # Test rescaling where we have to trim to a smaller size:
+    # diameter 1.2 mm, pixel scale 1 mm
+    test_optic_crop=fits.HDUList([fits.PrimaryHDU(np.zeros([1200,1200]))])
+    test_optic_crop[0].header["PUPLSCAL"]=.001
+    test_optic_crop_element=poppy_core.FITSOpticalElement(transmission=test_optic_crop)
+    assert(test_optic_crop_element.getPhasor(inputwf).shape ==inputwf.shape )


### PR DESCRIPTION
A revised test for `OpticalElement.getPhasor` rescaling that avoids the overly-large arrays encountered in #102 
Also adds explicit tests for padding and cropping the resized arrays. 