### PR TITLE
GetPhasor -> get_opd, get_transmission refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,10 @@ matrix:
         #- python: 2.7
         #  env: SETUP_CMD='test --coverage'
         # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
+        # may run for a long time. 
+        # Update: ignore warnings, just check for errors
         - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
+          env: SETUP_CMD='build_sphinx'
 
         # Try all python versions with the latest numpy
         - python: 2.7

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -133,18 +133,28 @@ such as Zemax or Code V for design of full optical systems.
 Defining your own custom optics
 ----------------------------------
 
-All `~poppy.OpticalElement` classes must have a method `~poppy.OpticalElement.getPhasor` which returns the complex phasor representing that optic, sampled appropriately for a given input `~poppy.Wavefront` and at the appropriate wavelength. To define your own custom OpticalElements, you can:
+All `~poppy.OpticalElement` classes must have methods
+`~poppy.OpticalElement.get_transmission` and `~poppy.OpticalElement.get_opd`
+which returns the amplitude transmission and optical path delay representing
+that optic, sampled appropriately for a given input `~poppy.Wavefront` and at
+the appropriate wavelength. These are combined together to calculate the
+complex phasor which is applied to the wavefront's electric field.  To define
+your own custom OpticalElements, you can:
 
-1. Subclass `~poppy.AnalyticOpticalElement` and write a suitable `getPhasor` function to describe the properties of your optic, 
-2. Combine two or more existing `~poppy.AnalyticOpticalElement` instances as part of a `~poppy.CompoundAnalyticOptic`, or
-3. Generate suitable transmission and phase (optical path difference) arrays using some other tool, save them as FITS files with appropriate keywords, and instantiate them as an `~poppy.FITSOpticalElement`
+1. Subclass `~poppy.AnalyticOpticalElement` and write suitable function(s) to
+   describe the properties of your optic, 
+2. Combine two or more existing `~poppy.AnalyticOpticalElement` instances as
+   part of a `~poppy.CompoundAnalyticOptic`, or
+3. Generate suitable transmission and optical path difference arrays
+   using some other tool, save them as FITS files with appropriate keywords,
+   and instantiate them as an `~poppy.FITSOpticalElement`
 
 
 FITSOpticalElements have separate attributes for amplitude and phase components, which may be read separately from 2 FITS files:
 
   * `amplitude`, the electric field amplitude transmission of the optic
-  * `opd`, the Optical Path Difference (phase delay) of the optic
+  * `opd`, the optical path difference of the optic
 
-AnalyticOpticalElements only need to implement the `getPhasor()` function, which allows more flexibility for amplitude transmission or phase delay to vary with wavelength or other properties. 
+Defining functions on a AnalyticOpticalElement subclass allows more flexibility for amplitude transmission or OPDs to vary with wavelength or other properties. 
 
 See :ref:`extending` for more details and examples.

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -196,7 +196,7 @@ class FresnelWavefront(Wavefront):
             Padding factor to apply to the wavefront array, multiplying on top of the beam radius.
 
 
-        References:
+        References
         -------------------
         - Lawrence, G. N. (1992), Optical Modeling, in Applied Optics and Optical Engineering., vol. XI,
             edited by R. R. Shannon and J. C. Wyant., Academic Press, New York.
@@ -205,11 +205,11 @@ class FresnelWavefront(Wavefront):
 
         - IDEX Optics and Photonics(n.d.), Gaussian Beam Optics,
             [online] Available from:
-             https://marketplace.idexop.com/store/SupportDocuments/All_About_Gaussian_Beam_OpticsWEB.pdf
+            https://marketplace.idexop.com/store/SupportDocuments/All_About_Gaussian_Beam_OpticsWEB.pdf
 
         - Krist, J. E. (2007), PROPER: an optical propagation library for IDL,
-           vol. 6675, p. 66750P-66750P-9.
-        [online] Available from: http://dx.doi.org/10.1117/12.731179
+            vol. 6675, p. 66750P-66750P-9.
+            [online] Available from: http://dx.doi.org/10.1117/12.731179
 
         - Andersen, T., and A. Enmark (2011), Integrated Modeling of Telescopes, Springer Science & Business Media.
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -54,7 +54,7 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
             self.z_m = z * u.m
 
 
-    def getPhasor(self, wave):
+    def get_phasor(self, wave):
         """ return complex phasor for the quadratic phase
 
         Parameters
@@ -88,7 +88,7 @@ class _QuadPhaseShifted(QuadPhase):
     def __init__(self, z, **kwargs):
         QuadPhase.__init__(self, z, **kwargs)
 
-    def getPhasor(self, wave):
+    def get_phasor(self, wave):
         """ Return complex phasor, for FFT shifted array
 
         Parameters
@@ -96,7 +96,7 @@ class _QuadPhaseShifted(QuadPhase):
         wave : object
             FresnelWavefront instance
         """
-        return np.fft.fftshift(super(_QuadPhaseShifted, self).getPhasor(wave))
+        return np.fft.fftshift(super(_QuadPhaseShifted, self).get_phasor(wave))
 
 
 class QuadraticLens(QuadPhase):
@@ -844,7 +844,6 @@ class FresnelWavefront(Wavefront):
         """
 
         _log.debug("------ Applying Lens: " + str(optic.name) + " ------")
-        # _log.debug("   wavefront oversample: {0}  optic oversample: {1}".format(self.oversample, optic.oversample))
         _log.debug("  Pre-Lens Beam Parameters: " + self.param_str)
 
         # calculate beam radius at current surface

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -28,15 +28,13 @@ __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission'
 # ------ Generic Analytic elements -----
 
 class AnalyticOpticalElement(OpticalElement):
-    """ Defines an abstract analytic optical element, i.e. one definable by some
-        formula rather than by an input OPD or pupil file.
+    """ Defines an abstract analytic optical element, i.e. one definable by
+        some formula rather than by an input OPD or pupil file.
 
         This class is useless on its own; instead use its various subclasses
-        that implement appropriate getPhasor functions. It exists mostly to
-        provide some behaviors & initialization common to all analytic optical
-        elements.
-
-
+        that implement appropriate get_opd and/or get_transmission functions.
+        It exists mostly to provide some behaviors & initialization common to
+        all analytic optical elements.
 
         Parameters
         ----------
@@ -78,8 +76,37 @@ class AnalyticOpticalElement(OpticalElement):
         else:
             return "Optic: " + self.name
 
-    def getPhasor(self, wave):
-        raise NotImplementedError("getPhasor must be supplied by a derived subclass")
+    # The following two functions should be replaced by derived subclasses 
+    # but we provide a default of perfect transmission and zero OPD.
+    def get_opd(self, wave):
+        return 0
+
+    def get_transmission(self, wave):
+        return 1
+
+    def get_phasor(self, wave):
+        """ Compute a complex phasor from an OPD, given a wavelength.
+
+        The returned value should be the complex phasor array as appropriate for
+        multiplying by the wavefront amplitude.
+
+        Parameters
+        ----------
+        wave : float or obj
+            either a scalar wavelength or a Wavefront object
+
+        """
+        if isinstance(wave, Wavefront):
+            wavelength=wave.wavelength
+        else:
+            wavelength=wave
+        scale = 2. * np.pi / wavelength
+
+        return self.get_transmission(wave) * np.exp (1.j * self.get_opd(wave) * scale)
+
+    def getPhasor(self,wave):
+        #TODO add deprecation warning here?
+        return self.get_phasor(wave)
 
     def sample(self, wavelength=2e-6, npix=512, grid_size=None, what='amplitude',
                return_scale=False, phase_unit='waves'):
@@ -128,7 +155,7 @@ class AnalyticOpticalElement(OpticalElement):
             pixel_scale = fov / npix
             w = Wavefront(wavelength=wavelength, npix=npix, pixelscale=pixel_scale)
 
-        phasor = self.getPhasor(w)
+        phasor = self.get_phasor(w)
         _log.info("Computing {0} for {1} sampled onto {2} pixel grid".format(what, self.name, npix))
         if what == 'amplitude':
             output_array = np.abs(phasor)
@@ -302,7 +329,7 @@ class ScalarTransmission(AnalyticOpticalElement):
         AnalyticOpticalElement.__init__(self, name=name, **kwargs)
         self.transmission = float(transmission)
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         res = np.empty(wave.shape)
         res.fill(self.transmission)
         return res
@@ -316,12 +343,11 @@ class InverseTransmission(OpticalElement):
     """
 
     def __init__(self, optic=None):
-        if optic is None or not hasattr(optic, 'getPhasor'):
+        if optic is None or not hasattr(optic, 'get_transmission'):
             raise ValueError("Need to supply an valid optic to invert!")
         self.uninverted_optic = optic
         self.name = "1 - " + optic.name
         self.planetype = optic.planetype
-        #self.shape = optic.shape
         self.pixelscale = optic.pixelscale
         self.oversample = optic.oversample
 
@@ -329,8 +355,8 @@ class InverseTransmission(OpticalElement):
     def shape(self): # override parent class shape function
         return self.uninverted_optic.shape
 
-    def getPhasor(self, wave):
-        return 1 - self.uninverted_optic.getPhasor(wave)
+    def get_transmission(self, wave):
+        return 1 - self.uninverted_optic.get_transmission(wave)
 
 
 #------ Analytic Image Plane elements (coordinates in arcsec) -----
@@ -385,7 +411,7 @@ class BandLimitedCoron(AnalyticImagePlaneElement):
                                                  # linear wedge option only
         self._default_display_size = 20.  # default size for onscreen display, sized for NIRCam
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the amplitude transmission appropriate for a BLC for some given pixel spacing
         corresponding to the supplied Wavefront.
 
@@ -399,7 +425,7 @@ class BandLimitedCoron(AnalyticImagePlaneElement):
 
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("BLC getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("BLC get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == _IMAGE)
 
         y, x = self.get_coordinates(wave)
@@ -544,13 +570,13 @@ class IdealFQPM(AnalyticImagePlaneElement):
 
         self.central_wavelength = wavelength
 
-    def getPhasor(self, wave):
-        """ Compute the amplitude transmission appropriate for a 4QPM for some given pixel spacing
+    def get_opd(self, wave):
+        """ Compute the OPD appropriate for a 4QPM for some given pixel spacing
         corresponding to the supplied Wavefront
         """
 
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("4QPM getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("4QPM get_opd must be called with a Wavefront to define the spacing")
         assert (wave.planetype == _IMAGE)
 
         # TODO this computation could be sped up a lot w/ optimzations
@@ -562,13 +588,9 @@ class IdealFQPM(AnalyticImagePlaneElement):
         phase[n0:, :n0] = 0
         phase[:n0, n0:] = 0
 
-        retardance = phase * self.central_wavelength / wave.wavelength
+        retardance = phase * self.central_wavelength
+        return retardance
 
-        #outFITS = fits.HDUList(fits.PrimaryHDU(retardance))
-        #outFITS.writeto('retardance_fqpm.fits', clobber=True)
-        #_log.info("Retardance is %f waves" % retardance.max())
-        FQPM_phasor = np.exp(1.j * 2 * np.pi * retardance)
-        return FQPM_phasor
 
 
 class RectangularFieldStop(AnalyticImagePlaneElement):
@@ -589,11 +611,11 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
         self.height = float(height)  # height of square stop in arcseconds.
         self._default_display_size = max(height, width) * 1.2
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("IdealFieldStop getPhasor must be called with a Wavefront "
+            raise ValueError("IdealFieldStop get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype == _IMAGE)
 
@@ -652,11 +674,11 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
         self.radius_outer = radius_outer  # radius of circular field stop in arcseconds.
         self._default_display_size = 10 #radius_outer
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == _IMAGE)
 
         y, x = self.get_coordinates(wave)
@@ -708,11 +730,11 @@ class BarOcculter(AnalyticImagePlaneElement):
         self.width = width
         self._default_display_size = 10
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == _IMAGE)
 
         y, x = self.get_coordinates(wave)
@@ -754,13 +776,13 @@ class FQPM_FFT_aligner(AnalyticOpticalElement):
         self._suppress_display = True
         #self.displayable = False
 
-    def getPhasor(self, wave):
+    def get_opd(self, wave):
         """ Compute the required tilt needed to get the PSF centered on the corner between
         the 4 central pixels, not on the central pixel itself.
         """
 
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("FQPM getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("FQPM get_opd must be called with a Wavefront to define the spacing")
         assert wave.planetype != _IMAGE, "This optic does not work on image planes"
 
         fft_im_pixelscale = wave.wavelength / wave.diam / wave.oversample * _RADIANStoARCSEC
@@ -773,8 +795,7 @@ class FQPM_FFT_aligner(AnalyticOpticalElement):
         wave.tilt(required_offset, required_offset)
 
         # gotta return something... so return a value that will not affect the wave any more.
-        align_phasor = 1.0
-        return align_phasor
+        return 0 # null OPD
 
 
 class ParityTestAperture(AnalyticOpticalElement):
@@ -804,11 +825,11 @@ class ParityTestAperture(AnalyticOpticalElement):
         # for creating input wavefronts - let's pad a bit:
         self.pupil_diam = pad_factor * 2 * self.radius
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("CircularAperture getPhasor must be called with a Wavefront "
+            raise ValueError("CircularAperture get_opd must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != _IMAGE)
 
@@ -865,11 +886,11 @@ class CircularAperture(AnalyticOpticalElement):
         self.pupil_diam = pad_factor * 2 * self.radius
 
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("CircularAperture getPhasor must be called with a Wavefront "
+            raise ValueError("CircularAperture get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != _IMAGE)
 
@@ -931,11 +952,11 @@ class HexagonAperture(AnalyticOpticalElement):
         return self.side*np.sqrt(3.)
 
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("HexagonAperture getPhasor must be called with a Wavefront "
+            raise ValueError("HexagonAperture get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != _IMAGE)
 
@@ -1131,12 +1152,11 @@ class MultiHexagonAperture(AnalyticOpticalElement):
 
         return ypos, xpos
 
-
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
         #y, x = self.get_coordinates(wave)
@@ -1204,11 +1224,11 @@ class NgonAperture(AnalyticOpticalElement):
         if name is None: name = "%d-gon, radius= %.1f m" % (self.nsides, self.radius)
         AnalyticOpticalElement.__init__(self, name=name, planetype=_PUPIL, rotation=rotation, **kwargs)
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
         y, x = self.get_coordinates(wave)
 
@@ -1253,11 +1273,11 @@ class RectangleAperture(AnalyticOpticalElement):
         # for creating input wavefronts:
         self.pupil_diam = np.sqrt(self.height ** 2 + self.width ** 2)
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
 #        y, x = wave.coordinates()
@@ -1351,11 +1371,11 @@ class SecondaryObscuration(AnalyticOpticalElement):
         # for creating input wavefronts if this is the first optic in a opticalsystem:
         self.pupil_diam = 4 * self.secondary_radius
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the obscuration
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
         self.transmission = np.ones(wave.shape)
@@ -1425,11 +1445,11 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
         self.support_offset_y = support_offset_y
 
 
-    def getPhasor(self, wave):
+    def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the obscuration
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
         self.transmission = np.ones(wave.shape)
@@ -1480,22 +1500,25 @@ class ThinLens(CircularAperture):
         self.max_phase_delay = reference_wavelength * nwaves
         CircularAperture.__init__(self, name=name, radius=radius, **kwargs)
 
-    def getPhasor(self, wave):
+    def get_opd(self, wave):
         y, x = self.get_coordinates(wave)
         r = np.sqrt(x ** 2 + y ** 2)
         r_norm = r / self.radius
 
         # the thin lens, being circular, is implicitly also a circular aperture:
-        aperture_intensity = CircularAperture.getPhasor(self, wave)
+        aperture_intensity = CircularAperture.get_transmission(self, wave)
+        # we use the aperture instensity here to mask the OPD we return
 
         # don't forget the factor of 0.5 to make the scaling factor apply as peak-to-valley
         # rather than center-to-peak
         defocus_zernike = ((2 * r_norm ** 2 - 1) *
                            (0.5 * self.nwaves * self.reference_wavelength / wave.wavelength))
 
-        lens_phasor = aperture_intensity* np.exp(1.j * 2 * np.pi * defocus_zernike * aperture_intensity)
+        opd = defocus_zernike * aperture_intensity
+        return opd
+        #lens_phasor = np.exp(1.j * 2 * np.pi * defocus_zernike * aperture_intensity)
 
-        return lens_phasor
+        #return lens_phasor
 
 
 class GaussianAperture(AnalyticOpticalElement):
@@ -1624,9 +1647,9 @@ class CompoundAnalyticOptic(AnalyticOpticalElement):
             if all([hasattr(o, 'pupil_diam') for o in self.opticslist]):
                 self.pupil_diam = np.asarray([o.pupil_diam for o in self.opticslist]).max()
 
-    def getPhasor(self, wave):
+    def get_phasor(self, wave):
         phasor = np.ones(wave.shape, dtype=np.complex)
         for optic in self.opticslist:
-            nextphasor = optic.getPhasor(wave)
+            nextphasor = optic.get_phasor(wave)
             phasor *= nextphasor
         return phasor

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -26,6 +26,7 @@ __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission'
            'SquareAperture', 'SecondaryObscuration', 'AsymmetricSecondaryObscuration',
            'ThinLens', 'GaussianAperture', 'CompoundAnalyticOptic']
 
+
 # ------ Generic Analytic elements -----
 
 class AnalyticOpticalElement(OpticalElement):
@@ -325,6 +326,7 @@ class AnalyticOpticalElement(OpticalElement):
     #PEP8 compliant aliases; the old names will later be deprecated
     to_fits = toFITS
 
+
 class ScalarTransmission(AnalyticOpticalElement):
     """ Uniform transmission between 0 and 1.0 in intensity.
 
@@ -370,6 +372,7 @@ class InverseTransmission(OpticalElement):
     def get_opd(self, wave):
         return self.uninverted_optic.get_opd(wave)
 
+
 #------ Analytic Image Plane elements (coordinates in arcsec) -----
 
 class AnalyticImagePlaneElement(AnalyticOpticalElement):
@@ -379,7 +382,6 @@ class AnalyticImagePlaneElement(AnalyticOpticalElement):
     """
     def __init__(self, name='Generic image plane optic', *args, **kwargs):
         AnalyticOpticalElement.__init__(self, name=name, planetype=_IMAGE, *args, **kwargs)
-
 
 
 class BandLimitedCoron(AnalyticImagePlaneElement):
@@ -599,9 +601,7 @@ class IdealFQPM(AnalyticImagePlaneElement):
         phase[n0:, :n0] = 0
         phase[:n0, n0:] = 0
 
-        retardance = phase * self.central_wavelength
-        return retardance
-
+        return phase * self.central_wavelength
 
 
 class RectangularFieldStop(AnalyticImagePlaneElement):

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -148,7 +148,6 @@ class AnalyticOpticalElement(OpticalElement):
             pixel_scale = diam / npix
 
         else:
-            #unit="arcsec"
 
             if grid_size is not None:
                 fov = grid_size
@@ -161,23 +160,23 @@ class AnalyticOpticalElement(OpticalElement):
 
         _log.info("Computing {0} for {1} sampled onto {2} pixel grid".format(what, self.name, npix))
         if what == 'amplitude':
-            output_array =  self.get_transmission(w) #np.abs(phasor)
+            output_array =  self.get_transmission(w)
         elif what == 'intensity':
-            output_array = self.get_transmission(w)**2 #np.abs(phasor) ** 2
+            output_array = self.get_transmission(w)**2
         elif what == 'phase':
             if phase_unit == 'radians':
                 output_array = np.angle(phasor) * 2 * np.pi / wavelength
             elif phase_unit == 'waves':
-                output_array = self.get_opd(w) / wavelength #  np.angle(phasor) / (2 * np.pi)
+                output_array = self.get_opd(w) / wavelength
             elif phase_unit == 'meters':
                 warnings.warn("'phase_unit' parameter has been deprecated. Use what='opd' instead.", category=DeprecationWarning)
-                output_array = self.get_opd(w)  #np.angle(phasor) / (2 * np.pi) * wavelength
+                output_array = self.get_opd(w)
             else:
                 warnings.warn("'phase_unit' parameter has been deprecated. Use what='opd' instead.", category=DeprecationWarning)
                 raise ValueError('Invalid/unknown phase_unit: {}. Must be one of '
                                  '[radians, waves, meters]'.format(phase_unit))
         elif what == 'opd':
-            output_array = self.get_opd(w)  #np.angle(phasor) / (2 * np.pi) * wavelength
+            output_array = self.get_opd(w)
         elif what == 'complex':
             output_array = self.get_phasor(w)
         else:
@@ -223,8 +222,6 @@ class AnalyticOpticalElement(OpticalElement):
         """
 
         _log.debug("Displaying " + self.name)
-        #phasor, pixelscale = self.sample(wavelength=wavelength, npix=npix, what='complex',
-                                         #grid_size=grid_size, return_scale=True)
         amplitude, pixelscale = self.sample(wavelength=wavelength, npix=npix, what='amplitude',
                                          grid_size=grid_size, return_scale=True)
         opd, pixelscale = self.sample(wavelength=wavelength, npix=npix, what='opd',
@@ -232,9 +229,8 @@ class AnalyticOpticalElement(OpticalElement):
 
 
         # temporarily set attributes appropriately as if this were a regular OpticalElement
-        self.amplitude = amplitude #np.abs(phasor)
-        #phase = np.angle(phasor) / (2 * np.pi)
-        self.opd = opd # phase * wavelength
+        self.amplitude = amplitude
+        self.opd = opd
         self.pixelscale = pixelscale
 
         #then call parent class display
@@ -789,7 +785,6 @@ class FQPM_FFT_aligner(AnalyticOpticalElement):
                              "forward or backward." % direction)
         self.direction = direction
         self._suppress_display = True
-        #self.displayable = False
 
     def get_opd(self, wave):
         """ Compute the required tilt needed to get the PSF centered on the corner between
@@ -849,7 +844,7 @@ class ParityTestAperture(AnalyticOpticalElement):
         assert (wave.planetype != _IMAGE)
 
         y, x = self.get_coordinates(wave)
-        r = np.sqrt(x ** 2 + y ** 2)  #* wave.pixelscale
+        r = np.sqrt(x ** 2 + y ** 2)
 
         w_outside = np.where(r > self.radius)
         self.transmission = np.ones(wave.shape)
@@ -1045,7 +1040,6 @@ class MultiHexagonAperture(AnalyticOpticalElement):
         self.flattoflat = self.side * np.sqrt(3)
         self.rings = rings
         self.gap = gap
-        #self._label_values = True # undocumented feature to draw hex indexes into the array
         AnalyticOpticalElement.__init__(self, name=name, planetype=_PUPIL, **kwargs)
 
         self.pupil_diam = (self.flattoflat + self.gap) * (2 * self.rings + 1)
@@ -1092,8 +1086,6 @@ class MultiHexagonAperture(AnalyticOpticalElement):
 
         # now count around from the starting point:
         index_in_ring = hex_index - self._nHexesInsideRing(ring) + 1  # 1-based
-        #print("hex %d is %dth in its ring" % (hex_index, index_in_ring))
-
         angle_per_hex = 2 * np.pi / self._nHexesInRing(ring)  # angle in radians
 
         # Now figure out what the radius is:
@@ -1174,9 +1166,6 @@ class MultiHexagonAperture(AnalyticOpticalElement):
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
-        #y, x = self.get_coordinates(wave)
-        #absy = np.abs(y)
-
         self.transmission = np.zeros(wave.shape)
 
         for i in self.segmentlist:
@@ -1210,7 +1199,6 @@ class MultiHexagonAperture(AnalyticOpticalElement):
             (absy <= (1 * self.side - x) * np.sqrt(3))
         )
 
-        #val = np.sqrt(float(index)) if self._label_values else 1
         val = 1
         self.transmission[w_rect] = val
         self.transmission[w_left_tri] = val
@@ -1256,8 +1244,7 @@ class NgonAperture(AnalyticOpticalElement):
         self.transmission = np.zeros(wave.shape)
         for row in range(wave.shape[0]):
             pts = np.asarray(list(zip(x[row], y[row])))
-            #ok = matplotlib.nxutils.points_inside_poly(pts, vertices)
-            ok = matplotlib.path.Path(vertices).contains_points(pts)  #, vertices)
+            ok = matplotlib.path.Path(vertices).contains_points(pts)
             self.transmission[row][ok] = 1.0
 
         return self.transmission
@@ -1295,16 +1282,6 @@ class RectangleAperture(AnalyticOpticalElement):
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != _IMAGE)
 
-#        y, x = wave.coordinates()
-#
-#        if self.rotation != 0:
-#            angle = np.deg2rad(self.rotation)
-#            xp = np.cos(angle) * x + np.sin(angle) * y
-#            yp = -np.sin(angle) * x + np.cos(angle) * y
-#
-#            x = xp
-#            y = yp
-#
         y, x = self.get_coordinates(wave)
 
         w_outside = np.where(
@@ -1531,9 +1508,6 @@ class ThinLens(CircularAperture):
 
         opd = defocus_zernike * aperture_intensity
         return opd
-        #lens_phasor = np.exp(1.j * 2 * np.pi * defocus_zernike * aperture_intensity)
-
-        #return lens_phasor
 
 
 class GaussianAperture(AnalyticOpticalElement):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -191,7 +191,7 @@ class Wavefront(object):
             # detectors don't modify a wavefront.
             return self
 
-        phasor = optic.getPhasor(self)
+        phasor = optic.get_phasor(self)
 
         if not np.isscalar(phasor) and phasor.size>1:  # actually isscalar() does not handle the case of a 1-element array properly
             assert self.wavefront.shape == phasor.shape
@@ -2022,11 +2022,41 @@ class OpticalElement(object):
         self.ispadded = False           # are we padded w/ zeros for oversampling the FFT?
         self._suppress_display=False    # should we avoid displaying this optic on screen? (useful for 'virtual' optics like FQPM aligner)
 
-        #_log.warn("Creating a null optical element. Are you sure that's what you want to do?")
         self.amplitude = np.asarray([1.])
         self.opd = np.asarray([0.])
         self.pixelscale = None
         self.interp_order=interp_order
+
+    def get_transmission(self, wave):
+        """ Return the amplitude transmission, given a wavelength.
+
+        Parameters
+        ----------
+        wave : float or obj
+            either a scalar wavelength or a Wavefront object
+
+        Returns
+        --------
+        ndarray giving amplitude transmission between 0 - 1.0
+
+        """
+        return self.amplitude
+
+    def get_opd(self, wave):
+        """ Return the optical path difference, given a wavelength.
+
+        Parameters
+        ----------
+        wave : float or obj
+            either a scalar wavelength or a Wavefront object
+
+        Returns
+        --------
+        ndarray giving OPD in meters
+
+        """
+        return self.opd
+
     def getPhasor(self,wave):
         """ Compute a complex phasor from an OPD, given a wavelength.
 
@@ -2103,6 +2133,8 @@ class OpticalElement(object):
             return utils.padToSize(self.phasor, wave.shape)
         else:
             return self.phasor
+
+
 
     def display(self, nrows=1, row=1, what='intensity', crosshairs=True, ax=None, colorbar=True,
                 colorbar_orientation=None, title=None, opd_vmax=0.5e-6):

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -414,7 +414,7 @@ def test_GaussianAperture(display=False):
             #super(poppy.Wavefront, self).__init__(*args, **kwargs) # super does not work for some reason?
             poppy_core.Wavefront.__init__(self, *args, **kwargs)
 
-            self.wavefront = np.ones(5)
+            self.wavefront = np.ones(5, dtype=np.complex128)
             self.planetype=poppy_core.PlaneType.pupil
             self.pixelscale = 0.5
         def coordinates(self):
@@ -441,14 +441,14 @@ def test_ThinLens(display=False):
     wave *= pupil
     wave *= lens
 
-    assert np.abs(wave.phase.max() - np.pi/2) < 1e-19
-    assert np.abs(wave.phase.min() + np.pi/2) < 1e-19
+    assert np.allclose(wave.phase.max(),  np.pi/2)
+    assert np.allclose(wave.phase.min(), -np.pi/2)
 
     # regression test to ensure null optical elements don't change ThinLens behavior
     # see https://github.com/mperrin/poppy/issues/14
     osys = poppy_core.OpticalSystem()
     osys.addPupil(optics.CircularAperture(radius=1))
-    for i in range(10):
+    for i in range(3):
         osys.addImage()
         osys.addPupil()
 

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -95,7 +95,7 @@ def test_SquareFieldStop():
 
 
 def test_BarOcculter():
-    optic= optics.BarOcculter(width=1, angle=0)
+    optic= optics.BarOcculter(width=1, rotation=0)
     wave = poppy_core.Wavefront(npix=100, pixelscale=0.1, wavelength=1e-6) # 10x10 arcsec square
 
     wave*= optic

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -232,7 +232,7 @@ class ZernikeWFE(WavefrontError):
 
         # the Zernike optic, being normalized on a circle, is
         # implicitly also a circular aperture:
-        aperture_intensity = self.circular_aperture.getPhasor(wave)
+        aperture_intensity = self.circular_aperture.get_transmission(wave)
 
         combined_zernikes = np.zeros(wave.shape, dtype=np.float64)
         for j, k in enumerate(self.coefficients, start=1):


### PR DESCRIPTION
This PR implements the API change proposed in #158 : the `getPhasor` function is replaced with `get_phasor` (renamed for PEP8 compliance), which then calls new functions `get_opd` and `get_transmission` which do the actual work.

The benefits of this are:
- Easier to define and extend subclasses since you can deal with the amplitude transmission and path delay components separately. Many optics such as pupil stops and coronagraph masks etc only need to define `get_transmission`, and so forth. 
- For plotting purposes it will let the actual OPD be displayed on screen even if the OPD is > 1 wave, which would get phase-wrapped before with the `getPhasor` implementation. 

Since this is a good sized API change, I'd like to get comments before merging it. @josePhoenix @neilzim @douglase what do you think?   Note that I've left in back-compatibility aliases for `getPhasor` for now, which can be removed in some future version. 


(note the commit history attached got a little screwy with repeated commits due to some git branch/rebase shenanigans. mea culpa. so, looking at the overall file deltas is a better way to see what changes than the individual commits)