### PR TITLE
Use astropy.Quantities for all wavelengths everywhere

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ The following are *optional*.  The first, :py:mod:`pysynphot`, is recommended
 for most users. The other optional installs are only worth adding for speed
 improvements if you are spending substantial time running calculations.
 
-* `pysynphot <http://ssb.stsci.edu/pysynphot/docs/>`_ enables the simulation
+* `pysynphot <http://pysynphot.readthedocs.org/en/latest/>`_ enables the simulation
   of PSFs with proper spectral response to realistic source spectra.  Without
   this, PSF fidelity is reduced. See below for :ref:`installation instructions
   for pysynphot <pysynphot_install>`. 
@@ -57,29 +57,15 @@ improvements if you are spending substantial time running calculations.
 Installing or updating pysynphot
 ----------------------------------
 
-`Pysynphot <http://ssb.stsci.edu/pysynphot/docs/>`_ is an optional dependency, but is highly recommended.
-See the `pysynphot installation instructions here <http://ssb.stsci.edu/pysynphot/docs/#installation-and-setup>`_.
-
-Briefly, to install or update ``pysynphot`` from the latest release zip file, 
-invoke::
-
-        pip install https://github.com/spacetelescope/pysynphot/archive/0.9.8.2.zip
-
-``Pysynphot`` requires some data files to work on. If you do not already have them installed, you will need to
-install these CDBS files, which are available at
-http://ssb.stsci.edu/pysynphot/docs/. 
-Download one or more of the
-archives numbered ``synphot[1-6].tar.gz`` and extract them to a directory such
-as ``$HOME/data/CDBS``. 
-Set the environment variable ``PYSYN_CDBS`` to point
-to that directory. e.g. ``setenv PYSYN_CDBS $HOME/data/CDBS`` for tcsh/csh or
-``export PYSYN_CDBS="$HOME/data/CDBS"`` for bash.
+`Pysynphot <http://pysynphot.readthedocs.org/en/latest/>`_ is an optional dependency, but is highly recommended.
+See the `pysynphot installation docs here <http://pysynphot.readthedocs.org/en/latest/#installation-and-setup>`_ 
+to install ``pysynphot`` and (at least some of) its CDBS data files.
 
 *The minimum needed to have stellar spectral models available for use when
-creating PSFs is just the Castelli & Kurucz stellar atlas, file*
+creating PSFs is pysynphot itself plus just one of the CDBS data files: the Castelli & Kurucz stellar atlas, file*
 `synphot3.tar.gz <ftp://ftp.stsci.edu/cdbs/tarfiles/synphot3.tar.gz>`_ (18
-MB). Feel free to ignore the rest of the synphot files unless you know you want a larger set of
-input spectra.
+MB). Feel free to ignore the rest of the synphot CDBS files unless you know you want a larger set of
+input spectra or need the reference files for other purposes.
 
 
 Testing your installation of poppy

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -7,6 +7,29 @@ For a list of contributors, see :ref:`about`.
 .. _whatsnew:
 
 
+0.5
+---
+
+*2016 June ish:*
+
+A couple moderately large enhancements. While we have tested this code extensively, it is possible that there may be
+some lingering bugs. As always, please let us know of any issues encountered via `the github issues page 
+<https://github.com/mperrin/poppy/issues/>`_.
+
+ * Increased use of ``astropy.units`` to put physical units on quantities, in
+   particular wavelengths, pixel scales, etc. Instead of wavelengths always being
+   implicitly in meters, you can now explicitly say e.g. ``wavelength=1*u.micron``, 
+   ``wavelength=500*u.nm``, etc. You can also generally use Quantities for 
+   arguments to OpticalElement classes, e.g. ``radius=2*u.cm``. This is *optional*; the
+   API still accepts bare floating-point numbers which are treated as implicitly in meters.
+ * The ``getPhasor`` function for all OpticalElements has been refactored to split it into 3
+   functions: ``get_transmission`` (for electric field amplitude transmission), ``get_opd``
+   (for the optical path difference affectig the phase), and ``get_phasor`` (which combines transmission and OPD into
+   the complex phasor). This division simplifies and makes more flexible the subclassing of optics, since
+   in many cases (such as aperture stops) one only cares about setting either the transmission or the OPD.
+   Again, there are back compatibility hooks to allow existing code calling the deprecated ``getPhasor``
+   function to continue working.
+
 
 0.4.1
 -----

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -427,7 +427,7 @@ class FresnelWavefront(Wavefront):
 
         y, x = np.indices(shape, dtype=float)
         pixelscale_mpix = pixelscale.to(u.meter/u.pixel).value
-        if not np.isscalar(pixelscale.value):
+        if not np.isscalar(pixelscale_mpix):
             pixel_scale_x, pixel_scale_y = pixelscale_mpix
         else:
             pixel_scale_x, pixel_scale_y = pixelscale_mpix, pixelscale_mpix
@@ -492,7 +492,7 @@ class FresnelWavefront(Wavefront):
     def fov(self):
         """ FOV in arcseconds, if applicable"""
         if self.angular_coordinates:
-            return np.asarray(self.wavefront.shape) * self.pixelscale
+            return np.asarray(self.wavefront.shape) *u.pixel * self.pixelscale
         else:
             return None
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -39,19 +39,21 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
 
     """
 
+    @utils.quantity_input(z=u.m)
     def __init__(self,
-                 z,  # FIXME consider renaming fl? z seems ambiguous with distance.
+                 z=1*u.m,  # FIXME consider renaming fl? z seems ambiguous with distance.
                  planetype=PlaneType.intermediate,
                  name='Quadratic Wavefront Curvature Operator',
                  **kwargs):
         poppy.AnalyticOpticalElement.__init__(self, name=name, planetype=planetype, **kwargs)
         self.z = z
 
-        if isinstance(z, u.quantity.Quantity):
-            self.z_m = z.to(u.m)  # convert to meters.
-        else:
-            _log.debug("Assuming meters, phase {:.3g} has no units for Optic: " .format(z) + self.name)
-            self.z_m = z * u.m
+        #if isinstance(z, u.quantity.Quantity):
+            #self.z_m = z.to(u.m)  # convert to meters.
+        #else:
+            #_log.debug("Assuming meters, phase {:.3g} has no units for Optic: " .format(z) + self.name)
+            #self.z_m = z * u.m
+        self.z_m = z.to(u.m)  # convert to meters.
 
 
     def getPhasor(self, wave):
@@ -63,9 +65,6 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
             a Fresnel Wavefront object
         """
 
-        # if not isinstance(wave,Wavefront):
-        # raise TypeError("Must supply a Fresnel Wavefront")
-        # y, x = wave.coordinates()
         y, x = wave.coordinates()
         rsqd = (x ** 2 + y ** 2) * u.m ** 2
         _log.debug("Applying spherical phase curvature ={0:0.2e}".format(self.z_m))
@@ -116,8 +115,9 @@ class QuadraticLens(QuadPhase):
 
     """
 
+    @utils.quantity_input(f_lens=u.m)
     def __init__(self,
-                 f_lens,
+                 f_lens=1.0*u.m,
                  planetype=PlaneType.unspecified,
                  name='Quadratic Lens',
                  **kwargs):
@@ -126,11 +126,12 @@ class QuadraticLens(QuadPhase):
                            planetype=planetype,
                            name=name,
                            **kwargs)
-        if isinstance(f_lens, u.quantity.Quantity):
-            self.fl = f_lens.to(u.m)  # convert to meters.
-        else:
-            _log.warn("Assuming meters, focal length ({:.3g}) has no units for Optic: ".format(f_lens) + self.name)
-            self.fl = f_lens * u.m
+        #if isinstance(f_lens, u.quantity.Quantity):
+            #self.fl = f_lens.to(u.m)  # convert to meters.
+        #else:
+            #_log.warn("Assuming meters, focal length ({:.3g}) has no units for Optic: ".format(f_lens) + self.name)
+            #self.fl = f_lens * u.m
+        self.fl = f_lens.to(u.m)
         _log.debug("Initialized: " + self.name + ", fl ={0:0.2e}".format(self.fl))
 
     def __str__(self):

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -5,6 +5,7 @@ import scipy.special
 import scipy.ndimage.interpolation
 import matplotlib
 import astropy.io.fits as fits
+import astropy.units as u
 
 from . import utils
 from .version import version
@@ -16,6 +17,7 @@ _log = logging.getLogger('poppy')
 
 from poppy import zernike
 from .poppy_core import OpticalElement, Wavefront, PlaneType, _PUPIL, _IMAGE, _RADIANStoARCSEC
+from .utils import quantity_input
 
 __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission',
            'BandLimitedCoron', 'IdealFQPM', 'RectangularFieldStop', 'SquareFieldStop',
@@ -81,14 +83,15 @@ class AnalyticOpticalElement(OpticalElement):
     def getPhasor(self, wave):
         raise NotImplementedError("getPhasor must be supplied by a derived subclass")
 
-    def sample(self, wavelength=2e-6, npix=512, grid_size=None, what='amplitude',
+    @quantity_input(wavelength=u.meter)
+    def sample(self, wavelength=2e-6*u.meter, npix=512, grid_size=None, what='amplitude',
                return_scale=False, phase_unit='waves'):
         """ Sample the Analytic Optic onto a grid and return the array
 
         Parameters
         ----------
-        wavelength : float
-            Wavelength in meters.
+        wavelength : astropy.units.Quantity or float
+            Wavelength (in meters if unit not given explicitly)
         npix : integer
             Number of pixels for sampling the array
         grid_size : float
@@ -113,7 +116,7 @@ class AnalyticOpticalElement(OpticalElement):
                 diam = self.pupil_diam
             else:
                 diam = 6.5  # meters
-            w = Wavefront(wavelength=wavelength, npix=npix, diam=diam)
+            w = Wavefront(wavelength=wavelength.to(u.meter).value, npix=npix, diam=diam)
             pixel_scale = diam / npix
 
         else:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -159,7 +159,8 @@ class AnalyticOpticalElement(OpticalElement):
             return output_array
 
 
-    def display(self, nrows=1, row=1, wavelength=2e-6, npix=512, grid_size=None, **kwargs):
+    @quantity_input(wavelength=u.meter)
+    def display(self, nrows=1, row=1, wavelength=2e-6*u.meter, npix=512, grid_size=None, **kwargs):
         """Display an Analytic optic by first computing it onto a grid...
 
         Parameters
@@ -210,7 +211,8 @@ class AnalyticOpticalElement(OpticalElement):
         self.amplitude = None
         return returnvalue
 
-    def toFITS(self, outname=None, what='amplitude', wavelength=2e-6, npix=512, **kwargs):
+    @quantity_input(wavelength=u.meter)
+    def toFITS(self, outname=None, what='amplitude', wavelength=2e-6*u.meter, npix=512, **kwargs):
         """ Save an analytic optic computed onto a grid to a FITS file
 
         The FITS file is returned to the calling function, and may optionally be
@@ -371,6 +373,7 @@ class BandLimitedCoron(AnalyticImagePlaneElement):
     allowable_kinds = ['circular', 'linear']
     """ Allowable types of BLC supported by this class"""
 
+    @quantity_input(wavelength=u.meter)
     def __init__(self, name="unnamed BLC", kind='circular', sigma=1, wavelength=None, **kwargs):
         AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
 
@@ -541,7 +544,8 @@ class IdealFQPM(AnalyticImagePlaneElement):
 
     """
 
-    def __init__(self, name="unnamed FQPM ", wavelength=10.65e-6, **kwargs):
+    @quantity_input(wavelength=u.meter)
+    def __init__(self, name="unnamed FQPM ", wavelength=10.65e-6*u.meter, **kwargs):
         AnalyticImagePlaneElement.__init__(self, **kwargs)
         self.name = name
 
@@ -1476,7 +1480,8 @@ class ThinLens(CircularAperture):
         such that rho = 1 at r = `radius`.
     """
 
-    def __init__(self, name='Thin lens', nwaves=4.0, reference_wavelength=2e-6,
+    @quantity_input(reference_wavelength=u.meter)
+    def __init__(self, name='Thin lens', nwaves=4.0, reference_wavelength=2e-6*u.meter,
                  radius=None, **kwargs):
         self.reference_wavelength = reference_wavelength
         self.nwaves = nwaves

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -580,23 +580,13 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
         Descriptive name
     width, height: float
         Size of the field stop, in arcseconds. Default 0.5 width, height 5.
-    angle : float
-        Position angle of the field stop sides relative to
-        the detector +Y direction, in degrees counterclockwise.
-        (Deprecated; redundant with the 'rotation' parameter to
-        any AnalyticOpticalElement; kept for back compatibility.)
-
     """
 
-    def __init__(self, name="unnamed field stop", width=0.5, height=5.0, angle=None, **kwargs):
+    def __init__(self, name="unnamed field stop", width=0.5, height=5.0, **kwargs):
         AnalyticImagePlaneElement.__init__(self, **kwargs)
         self.name = name
         self.width = float(width)  # width of square stop in arcseconds.
         self.height = float(height)  # height of square stop in arcseconds.
-        if angle is not None:
-            import warnings
-            warnings.warn("'angle' parameter is deprecated. Use 'rotation' instead.", DeprecationWarning)
-            self.rotation= float(angle)
         self._default_display_size = max(height, width) * 1.2
 
     def getPhasor(self, wave):
@@ -634,17 +624,11 @@ class SquareFieldStop(RectangularFieldStop):
         Descriptive name
     size : float
         Size of the field stop, in arcseconds. Default 20.
-    angle : float
-        Position angle of the field stop sides relative to the detector +Y direction, in degrees.
-        (Deprecated; redundant with the 'rotation' parameter to
-        any AnalyticOpticalElement; kept for back compatibility.)
-
     """
 
-    def __init__(self, name="unnamed field stop", size=20., angle=None, **kwargs):
-        RectangularFieldStop.__init__(self, width=size, height=size, angle=angle, **kwargs)
+    def __init__(self, name="unnamed field stop", size=20., **kwargs):
+        RectangularFieldStop.__init__(self, width=size, height=size, **kwargs)
         self.name = name
-        #self.size = size            # size of square stop in arcseconds.
         self.height = self.width
         self._default_display_size = size * 1.2
 
@@ -715,22 +699,13 @@ class BarOcculter(AnalyticImagePlaneElement):
         Descriptive name
     width : float
         width of the bar stop, in arcseconds. Default is 1.0
-    angle : float
-        position angle of the bar, rotated relative to the normal +y direction.
-        (Deprecated; redundant with the 'rotation' parameter to
-        any AnalyticOpticalElement; kept for back compatibility.)
 
     """
 
-    def __init__(self, name="bar occulter", width=1.0, angle=None, **kwargs):
+    def __init__(self, name="bar occulter", width=1.0, **kwargs):
         AnalyticImagePlaneElement.__init__(self, **kwargs)
         self.name = name
         self.width = width
-        if angle is not None:
-            import warnings
-            warnings.warn("'angle' parameter is deprecated. Use 'rotation' instead.", DeprecationWarning)
-            self.rotation = angle
-        #self.pixelscale=0
         self._default_display_size = 10
 
     def getPhasor(self, wave):

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -427,7 +427,7 @@ class BandLimitedCoron(AnalyticImagePlaneElement):
         if wavelength is not None:
             self.wavelength = float(wavelength)  # wavelength, for selecting the
                                                  # linear wedge option only
-        self._default_display_size = 20.  # default size for onscreen display, sized for NIRCam
+        self._default_display_size = 20.*u.arcsec  # default size for onscreen display, sized for NIRCam
 
     def get_transmission(self, wave):
         """ Compute the amplitude transmission appropriate for a BLC for some given pixel spacing
@@ -626,7 +626,7 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
         self.name = name
         self.width = float(width)  # width of square stop in arcseconds.
         self.height = float(height)  # height of square stop in arcseconds.
-        self._default_display_size = max(height, width) * 1.2
+        self._default_display_size = max(height, width) * 1.2*u.arcsec
 
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
@@ -669,7 +669,7 @@ class SquareFieldStop(RectangularFieldStop):
         RectangularFieldStop.__init__(self, width=size, height=size, **kwargs)
         self.name = name
         self.height = self.width
-        self._default_display_size = size * 1.2
+        self._default_display_size = size * 1.2*u.arcsec
 
 
 class AnnularFieldStop(AnalyticImagePlaneElement):
@@ -689,7 +689,7 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
         self.name = name
         self.radius_inner = radius_inner  # radius of circular occulter in arcseconds.
         self.radius_outer = radius_outer  # radius of circular field stop in arcseconds.
-        self._default_display_size = 10 #radius_outer
+        self._default_display_size = 10*u.arcsec #radius_outer
 
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
@@ -726,7 +726,7 @@ class CircularOcculter(AnnularFieldStop):
     """
     def __init__(self, name="unnamed occulter", radius=1.0, **kwargs):
         super(CircularOcculter,self).__init__(name=name,radius_inner=radius, radius_outer=0.0, **kwargs)
-        self._default_display_size = 10
+        self._default_display_size = 10*u.arcsec
 
 
 class BarOcculter(AnalyticImagePlaneElement):
@@ -745,7 +745,7 @@ class BarOcculter(AnalyticImagePlaneElement):
         AnalyticImagePlaneElement.__init__(self, **kwargs)
         self.name = name
         self.width = width
-        self._default_display_size = 10
+        self._default_display_size = 10*u.arcsec
 
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
@@ -1631,7 +1631,7 @@ class CompoundAnalyticOptic(AnalyticOpticalElement):
 
         #self.operation = operation
         self.opticslist = []
-        self._default_display_size = 3
+        self._default_display_size = 3*u.arcsec
         self.planetype = None
 
         for optic in opticslist:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -17,7 +17,6 @@ _log = logging.getLogger('poppy')
 
 from poppy import zernike
 from .poppy_core import OpticalElement, Wavefront, PlaneType, _PUPIL, _IMAGE, _RADIANStoARCSEC
-from .utils import quantity_input
 
 __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission',
            'BandLimitedCoron', 'IdealFQPM', 'RectangularFieldStop', 'SquareFieldStop',
@@ -83,7 +82,7 @@ class AnalyticOpticalElement(OpticalElement):
     def getPhasor(self, wave):
         raise NotImplementedError("getPhasor must be supplied by a derived subclass")
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def sample(self, wavelength=2e-6*u.meter, npix=512, grid_size=None, what='amplitude',
                return_scale=False, phase_unit='waves'):
         """ Sample the Analytic Optic onto a grid and return the array
@@ -159,7 +158,7 @@ class AnalyticOpticalElement(OpticalElement):
             return output_array
 
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def display(self, nrows=1, row=1, wavelength=2e-6*u.meter, npix=512, grid_size=None, **kwargs):
         """Display an Analytic optic by first computing it onto a grid...
 
@@ -211,7 +210,7 @@ class AnalyticOpticalElement(OpticalElement):
         self.amplitude = None
         return returnvalue
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def toFITS(self, outname=None, what='amplitude', wavelength=2e-6*u.meter, npix=512, **kwargs):
         """ Save an analytic optic computed onto a grid to a FITS file
 
@@ -373,7 +372,7 @@ class BandLimitedCoron(AnalyticImagePlaneElement):
     allowable_kinds = ['circular', 'linear']
     """ Allowable types of BLC supported by this class"""
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def __init__(self, name="unnamed BLC", kind='circular', sigma=1, wavelength=None, **kwargs):
         AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
 
@@ -544,7 +543,7 @@ class IdealFQPM(AnalyticImagePlaneElement):
 
     """
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def __init__(self, name="unnamed FQPM ", wavelength=10.65e-6*u.meter, **kwargs):
         AnalyticImagePlaneElement.__init__(self, **kwargs)
         self.name = name
@@ -1480,7 +1479,7 @@ class ThinLens(CircularAperture):
         such that rho = 1 at r = `radius`.
     """
 
-    @quantity_input(reference_wavelength=u.meter)
+    @utils.quantity_input(reference_wavelength=u.meter)
     def __init__(self, name='Thin lens', nwaves=4.0, reference_wavelength=2e-6*u.meter,
                  radius=None, **kwargs):
         self.reference_wavelength = reference_wavelength

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -115,7 +115,7 @@ class AnalyticOpticalElement(OpticalElement):
                 diam = self.pupil_diam
             else:
                 diam = 6.5  # meters
-            w = Wavefront(wavelength=wavelength.to(u.meter).value, npix=npix, diam=diam)
+            w = Wavefront(wavelength=wavelength, npix=npix, diam=diam)
             pixel_scale = diam / npix
 
         else:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -106,7 +106,7 @@ class AnalyticOpticalElement(OpticalElement):
             wavelength=wave.wavelength
         else:
             wavelength=wave
-        scale = 2. * np.pi / wavelength
+        scale = 2. * np.pi / wavelength.to(u.meter).value
 
         return self.get_transmission(wave) * np.exp (1.j * self.get_opd(wave) * scale)
 
@@ -607,7 +607,7 @@ class IdealFQPM(AnalyticImagePlaneElement):
         phase[n0:, :n0] = 0
         phase[:n0, n0:] = 0
 
-        return phase * self.central_wavelength
+        return phase * self.central_wavelength.to(u.meter).value
 
 
 class RectangularFieldStop(AnalyticImagePlaneElement):
@@ -1511,7 +1511,7 @@ class ThinLens(CircularAperture):
         # don't forget the factor of 0.5 to make the scaling factor apply as peak-to-valley
         # rather than center-to-peak
         defocus_zernike = ((2 * r_norm ** 2 - 1) *
-                           (0.5 * self.nwaves * self.reference_wavelength)) # / wave.wavelength))
+                           (0.5 * self.nwaves * self.reference_wavelength.to(u.meter).value))
 
         opd = defocus_zernike * aperture_intensity
         return opd

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -414,7 +414,7 @@ class Wavefront(object):
         # This is needed to get the coordinates right when displaying very small arrays
 
 
-        halfpix = self.pixelscale*0.5
+        halfpix = self.pixelscale.value*0.5
         extent = [x.min()-halfpix, x.max()+halfpix, y.min()-halfpix, y.max()+halfpix]
 
         if use_angular_coordinates is None:
@@ -535,8 +535,8 @@ class Wavefront(object):
                     imagecrop = conf.default_image_display_fov
 
             if imagecrop is not None:
-                cropsize_x = min( (imagecrop/2, intens.shape[1]/2.*self.pixelscale))
-                cropsize_y = min( (imagecrop/2, intens.shape[0]/2.*self.pixelscale))
+                cropsize_x = min( (imagecrop/2, intens.shape[1]/2.*self.pixelscale.value))
+                cropsize_y = min( (imagecrop/2, intens.shape[0]/2.*self.pixelscale.value))
                 ax.set_xbound(-cropsize_x, cropsize_x)
                 ax.set_ybound(-cropsize_y, cropsize_y)
 
@@ -1356,7 +1356,7 @@ class OpticalSystem(object):
 
             if display_intermediates:
                 if conf.enable_speed_tests: t0 = time.time()
-                title = None if current_plane_index > 1 else "propagating $\lambda=$ %.3f $\mu$m" % (wavelength*1e6)
+                title = None if current_plane_index > 1 else "propagating $\lambda=$ {0:.3f}".format(wavelength.to(u.micron))
                 wavefront.display(what='best',nrows=len(self.planes),row=current_plane_index, colorbar=False, title=title)
                 #plt.title("propagating $\lambda=$ %.3f $\mu$m" % (wavelength*1e6))
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -17,7 +17,6 @@ import astropy.units as u
 from .matrixDFT import MatrixFourierTransform
 from . import utils
 from . import conf
-from .utils import quantity_input
 
 import logging
 _log = logging.getLogger('poppy')
@@ -120,11 +119,8 @@ class Wavefront(object):
 
     """
 
-    @quantity_input(wavelength=u.meter, diam=u.meter, pixelscale=u.arcsec/u.pixel)
+    @utils.quantity_input(wavelength=u.meter, diam=u.meter, pixelscale=u.arcsec/u.pixel)
     def __init__(self,wavelength=2e-6*u.meter, npix=1024, dtype=np.complex128, diam=8.0*u.meter, oversample=2, pixelscale=None):
-
-        #if wavelength > 1e-3*u.m:
-            #raise ValueError("The specified wavelength {} is implausibly large. Remember to specify the desired wavelength in *meters*.".format( wavelength))
 
         self._last_transform_type=None # later used to track MFT vs FFT pixel coord centering in coordinates()
         self.oversample = oversample
@@ -1231,7 +1227,7 @@ class OpticalSystem(object):
         return self.planes[num]
 
     # methods for dealing with wavefronts:
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def inputWavefront(self, wavelength=2e-6*u.meter):
         """Create a Wavefront object suitable for sending through a given optical system, based on
         the size of the first optical plane, assumed to be a pupil.
@@ -1285,7 +1281,7 @@ class OpticalSystem(object):
             _log.debug("Tilted input wavefront by theta_X=%f, theta_Y=%f arcsec" % (offset_x, offset_y))
         return inwave
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def propagate_mono(self, wavelength=2e-6*u.meter, normalize='first',
                        retain_intermediates=False, display_intermediates=False):
         """Propagate a monochromatic wavefront through the optical system. Called from within `calcPSF`.
@@ -1373,7 +1369,7 @@ class OpticalSystem(object):
 
         return wavefront.asFITS(), intermediate_wfs
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def calcPSF(self, wavelength=1e-6*u.meter, weight=None, save_intermediates=False, save_intermediates_what='all',
                 display=False, return_intermediates=False, source=None, normalize='first', display_intermediates=False):
         """Calculate a PSF, either multi-wavelength or monochromatic.
@@ -1426,10 +1422,6 @@ class OpticalSystem(object):
         # (the check for a quantity of type length is applied in the decorator)
         if np.isscalar(wavelength.value):
             wavelength = np.asarray([wavelength.value], dtype=float)*wavelength.unit
-        #try:
-            #else: wavelength = np.asarray(wavelength, dtype=float)
-        #except (ValueError,TypeError):
-            #raise ValueError("You have specified an invalid wavelength to calcPSF: "+str(wavelength))
 
         if weight is None:
             weight = [1.0] * len(wavelength)
@@ -1710,7 +1702,7 @@ class SemiAnalyticCoronagraph(OpticalSystem):
 
         self.occulter_det = Detector(self.detector.pixelscale/self.oversample, fov_arcsec = self.occulter_box*2, name='Oversampled Occulter Plane')
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def propagate_mono(self, wavelength=2e-6*u.meter, normalize='first',
                        retain_intermediates=False, display_intermediates=False):
         """Propagate a monochromatic wavefront through the optical system. Called from within `calcPSF`.
@@ -1885,7 +1877,7 @@ class MatrixFTCoronagraph(OpticalSystem):
             occulter_box = np.array(occulter_box) # cast to numpy array so the multiplication by 2 just below will work
         self.occulter_box = occulter_box
 
-    @quantity_input(wavelength=u.meter)
+    @utils.quantity_input(wavelength=u.meter)
     def propagate_mono(self, wavelength=1e-6, normalize='first',
                        retain_intermediates=False, display_intermediates=False):
         """Propagate a monochromatic wavefront through the optical system using matrix FTs. Called from
@@ -2538,7 +2530,7 @@ class FITSOpticalElement(OpticalElement):
                 except ValueError:
                     raise ValueError("pixelscale=%s is neither a FITS keyword string "
                                      "nor a floating point value." % str(pixelscale))
-            # now turn the pixel scale into a quantityt
+            # now turn the pixel scale into a Quantity
             if self.planetype == _IMAGE:
                 self.pixelscale *= u.arcsec/u.pixel
             else: # pupil or any other types of plane
@@ -2634,7 +2626,7 @@ class Detector(OpticalElement):
         around an off-axis source. (Has not been tested!)
 
     """
-    @quantity_input(pixelscale=u.arcsec/u.pixel, fov_pixels=u.pixel, fov_arcsec=u.arcsec)
+    @utils.quantity_input(pixelscale=u.arcsec/u.pixel, fov_pixels=u.pixel, fov_arcsec=u.arcsec)
     def __init__(self, pixelscale=1*(u.arcsec/u.pixel), fov_pixels=None, fov_arcsec=None, oversample=1, name="Detector", offset=None, **kwargs):
         OpticalElement.__init__(self,name=name, planetype=_DETECTOR, **kwargs)
         self.pixelscale = pixelscale

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -36,54 +36,6 @@ def check_wavefront(filename_or_hdulist, slice=0, ext=0, test='nearzero', commen
 
 wavelength=2e-6
 
-class ParityTestAperture(optics.AnalyticOpticalElement):
-    """ Defines a circular pupil aperture with boxes cut out.
-    This is mostly a test aperture
-
-    Parameters
-    ----------
-    name : string
-        Descriptive name
-    radius : float
-        Radius of the pupil, in meters. Default is 1.0
-
-    pad_factor : float, optional
-        Amount to oversize the wavefront array relative to this pupil.
-        This is in practice not very useful, but it provides a straightforward way
-        of verifying during code testing that the amount of padding (or size of the circle)
-        does not make any numerical difference in the final result.
-
-    """
-
-    def __init__(self, name=None,  radius=1.0, pad_factor = 1.5, **kwargs):
-        if name is None: name = "Circle, radius=%.2f m" % radius
-        super(ParityTestAperture,self).__init__(name=name, **kwargs)
-        self.radius = radius
-        self.pupil_diam = pad_factor * 2* self.radius # for creating input wavefronts - let's pad a bit
-
-
-    def getPhasor(self,wave):
-        """ Compute the transmission inside/outside of the occulter.
-        """
-        if not isinstance(wave, poppy_core.Wavefront):
-            raise ValueError("CircularAperture getPhasor must be called with a Wavefront to define the spacing")
-        #assert (wave.planetype == poppy._PUPIL)
-
-        y, x = wave.coordinates()
-        r = np.sqrt(x**2+y**2) #* wave.pixelscale
-
-        w_outside = np.where( r > self.radius)
-        self.transmission = np.ones(wave.shape)
-        self.transmission[w_outside] = 0
-
-        w_box1 = np.where( (r> self.radius*0.5) & (np.abs(x) < self.radius*0.1 ) & ( y < 0 ))
-        w_box2 = np.where( (r> self.radius*0.65) & (np.abs(y) < self.radius*0.4) & ( x < 0 ))
-        self.transmission[w_box1] = 0
-        self.transmission[w_box2] = 0
-
-        return self.transmission
-
-
 
 ######### Core tests functions #########
 

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -33,13 +33,13 @@ if _HAVE_PYTEST:
 
         with pytest.raises(ValueError) as excinfo:
             psf = osys.calcPSF('cat')
-        assert _exception_message_starts_with(excinfo, 'You have specified an invalid wavelength to calcPSF:')
+        assert _exception_message_starts_with(excinfo, "Argument 'wavelength' to function 'calcPSF' must be a number")
 
 
-        source={'wavelengths': [1.0e-6, 1.1e-6, 1.2e-6, 1.3e-6], 'weights':[0.25, 0.25, 0.25, 0.25]}
+        source={'wavelengths': [1.0e-6, 'not a number', 1.2e-6, 1.3e-6], 'weights':[0.25, 0.25, 0.25, 0.25]}
         with pytest.raises(ValueError) as excinfo:
             psf = osys.calcPSF(source)
-        assert _exception_message_starts_with(excinfo, 'You have specified an invalid wavelength to calcPSF:')
+        assert _exception_message_starts_with(excinfo, "Argument 'wavelength' to function 'calcPSF' must be a number")
 
     def test_matrixDFT_catch_invalid_parameters():
         import numpy as np

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -92,7 +92,7 @@ if _HAVE_PYTEST:
 
 
     def test_CircularAperture_invalid_parameters():
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             optics.CircularAperture(radius='a')
-        assert _exception_message_starts_with(excinfo, "Argument 'radius' must be the radius of the pupil in meters")
+        assert _exception_message_starts_with(excinfo, "Argument 'radius' to function '__init__' must be a number")
 

--- a/poppy/tests/test_fft.py
+++ b/poppy/tests/test_fft.py
@@ -172,11 +172,9 @@ def test_parity_FFT_forward_inverse(display=False):
 
     """
 
-    from .test_core import ParityTestAperture
-
     # set up optical system with 2 pupil planes and 2 image planes
     sys = poppy_core.OpticalSystem(oversample=1)
-    sys.addPupil(ParityTestAperture())
+    sys.addPupil(optics.ParityTestAperture())
     sys.addImage()
     sys.addPupil()
     sys.addDetector(pixelscale=0.010, fov_arcsec=1)

--- a/poppy/tests/test_matrixDFT.py
+++ b/poppy/tests/test_matrixDFT.py
@@ -1,4 +1,4 @@
-#  
+# 
 #  Test functions for matrix DFT code
 #
 #
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import astropy.io.fits as fits
 
 import os
-from .. import poppy_core 
+from .. import poppy_core
 from .. import optics
 from .. import matrixDFT
 from .test_errorhandling import _exception_message_starts_with
@@ -58,7 +58,7 @@ def makedisk(s=None, c=None, r=None, inside=1.0, outside=0.0, grey=None, t=None)
     given center and size
     """
 
-    
+
     # fft style or sft asymmetric style - center = nx/2, ny/2
     # see ellipseDriver.py for details on symm...
 
@@ -73,7 +73,7 @@ def test_MFT_flux_conservation(centering='FFTSTYLE', outdir=None, outname='test_
     Test that MFTing a circular aperture is properly normalized to be flux conserving.
 
     This test is limited primarily by how finely the arrays are sampled. The function implements tests to
-    better than 1% or 0.1%, selectable using the 'precision' argument. 
+    better than 1% or 0.1%, selectable using the 'precision' argument.
 
     Parameters
     -----------
@@ -81,11 +81,11 @@ def test_MFT_flux_conservation(centering='FFTSTYLE', outdir=None, outname='test_
     outdir : path
         Directory path to output diagnostic FITS files. If not specified, files will not be written.
     precision : float, either 0.01 or 0.001
-        How precisely to expect flux conservation; it will not be strictly 1.0 given any finite array size. 
+        How precisely to expect flux conservation; it will not be strictly 1.0 given any finite array size.
         This function usesd predetermined MFT array sizes based on the desired precision level of the test.
     """
 
-    # Set up constants for either a more precise test or a less precise but much 
+    # Set up constants for either a more precise test or a less precise but much
     # faster test:
     print("Testing MFT flux conservation for centering = {}".format(centering))
     if precision ==0.001:
@@ -93,7 +93,7 @@ def test_MFT_flux_conservation(centering='FFTSTYLE', outdir=None, outname='test_
         npix = 4096
         u = 400    # of lam/D. Must be <= the Nyquist frequency of the pupil sampling or there
                    #           will be aliased copies of the PSF.
-    elif precision==0.01: 
+    elif precision==0.01:
         npupil = 400
         npix = 2048
         u = 200    # of lam/D. Must be <= the Nyquist frequency of the pupil sampling or there
@@ -115,7 +115,7 @@ def test_MFT_flux_conservation(centering='FFTSTYLE', outdir=None, outname='test_
     a = mft.perform(pupil, u, npix)
 
     pre = (abs(pupil)**2).sum()    # normalized area of input pupil, should be 1 by construction
-    post = (abs(a)**2).sum()       # 
+    post = (abs(a)**2).sum()       #
     ratio = post / pre
     print("Pre-FFT  total: "+str( pre))
     print("Post-FFT total: "+str( post ))
@@ -150,11 +150,11 @@ def test_DFT_rect(centering='FFTSTYLE', outdir=None, outname='DFT1R_', npix=None
     forward and inverse directions.
 
     This is an exact equivalent (in Python) of Marshall Perrin's
-    test_matrix_DFT in matrix_dft.pro (in IDL) 
+    test_matrix_DFT in matrix_dft.pro (in IDL)
     They should give identical results. However, this function doesn't actually
     check that since that would require having IDL...
     Instead it just checks that the sizes of the output arrays
-    are as requested. 
+    are as requested.
 
     """
 
@@ -169,9 +169,9 @@ def test_DFT_rect(centering='FFTSTYLE', outdir=None, outname='DFT1R_', npix=None
     # make things rectangular:
     if nlamd is None and npix is None:
         nlamd = (10,20)
-        npix = [val*sampling for val in nlamd] #(100, 200) 
+        npix = [val*sampling for val in nlamd] #(100, 200)
     elif npix is None:
-        npix = [val*sampling for val in nlamd] #(100, 200) 
+        npix = [val*sampling for val in nlamd] #(100, 200)
     elif nlamd is None:
         nlamd = [val/sampling for val in npix]
     u = nlamd
@@ -219,8 +219,8 @@ def test_DFT_rect(centering='FFTSTYLE', outdir=None, outname='DFT1R_', npix=None
 
 
 
-    pre = (abs(pupil)**2).sum() 
-    post = (abs(a)**2).sum() 
+    pre = (abs(pupil)**2).sum()
+    post = (abs(a)**2).sum()
     ratio = post / pre
     calcr = 1./(1.0*u[0]*u[1] *npix[0]*npix[1])     # multiply post by this to make them equal
     _log.info( "Pre-FFT  total: "+str( pre))
@@ -298,8 +298,8 @@ def test_DFT_center( npix=100, outdir=None, outname='DFT1'):
 
     a = mft1.perform(pupil, u, npix)
 
-    pre = (abs(pupil)**2).sum() 
-    post = (abs(a)**2).sum() 
+    pre = (abs(pupil)**2).sum()
+    post = (abs(a)**2).sum()
     ratio = post / pre
     calcr = 1./(u**2 *npix**2)     # multiply post by this to make them equal
     print("Pre-FFT  total: "+str( pre))
@@ -310,7 +310,7 @@ def test_DFT_center( npix=100, outdir=None, outname='DFT1'):
 
 
     complexinfo(a, str="mft1 asf")
-    #print 
+    #print
     asf = a.real.copy()
     cpsf = a * a.conjugate()
     psf = cpsf.real.copy()
@@ -321,7 +321,7 @@ def test_DFT_center( npix=100, outdir=None, outname='DFT1'):
 
 def test_DFT_rect_fov_sampling(fov_npix = (500,1000), pixelscale=0.03, display=False):
     """ Test that we can create a rectangular FOV which nonetheless
-    is properly sampled in both the X and Y directions as desired. 
+    is properly sampled in both the X and Y directions as desired.
     In this case specifically we test that we can get the a symmetric
     PSF (same pixel scale in both X and Y) even when the overall FOV
     is rectangular. This tests some of the low level normalizations and
@@ -457,11 +457,11 @@ def run_all_MFS_tests_DFT(outdir=None, outname='DFT1'):
     a5 = DFT_symmetric(pupil, u, npix)
 
     if outdir is not None:
-        fits.writeto(outdir+os.sep+outname+"_a1_fft.fits",(a1*a1.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_a2_sym.fits",(a2*a2.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_a3_adj.fits",(a3*a3.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_a4_fftr.fits",(a4*a4.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_a5_symr.fits",(a5*a5.conjugate()).real, clobber=True) 
+        fits.writeto(outdir+os.sep+outname+"_a1_fft.fits",(a1*a1.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_a2_sym.fits",(a2*a2.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_a3_adj.fits",(a3*a3.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_a4_fftr.fits",(a4*a4.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_a5_symr.fits",(a5*a5.conjugate()).real, clobber=True)
 
     npix=513
     b1 = DFT_combined(pupil, u, npix, centering='FFTSTYLE')
@@ -472,11 +472,11 @@ def run_all_MFS_tests_DFT(outdir=None, outname='DFT1'):
 
 
     if outdir is not None:
-        fits.writeto(outdir+os.sep+outname+"_b1_fft.fits",(b1*b1.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_b2_sym.fits",(b2*b2.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_b3_adj.fits",(b3*b3.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_b4_fftr.fits",(b4*b4.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_b5_symr.fits",(b5*b5.conjugate()).real, clobber=True) 
+        fits.writeto(outdir+os.sep+outname+"_b1_fft.fits",(b1*b1.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_b2_sym.fits",(b2*b2.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_b3_adj.fits",(b3*b3.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_b4_fftr.fits",(b4*b4.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_b5_symr.fits",(b5*b5.conjugate()).real, clobber=True)
 
 
     u2 = (u, u/4)
@@ -488,18 +488,18 @@ def run_all_MFS_tests_DFT(outdir=None, outname='DFT1'):
     c5 = DFT_adjustable_rect(pupil, u2, npix2)
 
     if outdir is not None:
-        fits.writeto(outdir+os.sep+outname+"_c1_fft.fits",(c1*c1.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_c2_sym.fits",(c2*c2.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_c3_adj.fits",(c3*c3.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_c4_fftr.fits",(c4*c4.conjugate()).real, clobber=True) 
-        fits.writeto(outdir+os.sep+outname+"_c5_adjr.fits",(c5*c5.conjugate()).real, clobber=True) 
+        fits.writeto(outdir+os.sep+outname+"_c1_fft.fits",(c1*c1.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_c2_sym.fits",(c2*c2.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_c3_adj.fits",(c3*c3.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_c4_fftr.fits",(c4*c4.conjugate()).real, clobber=True)
+        fits.writeto(outdir+os.sep+outname+"_c5_adjr.fits",(c5*c5.conjugate()).real, clobber=True)
 
 
     for c, label in zip([c1, c2, c3, c4,c5], ['comb-fft', 'comb-sym', 'comb-adj', 'fft_rect', 'adj_rect']) :
         print(label, c.shape)
 
 def test_check_invalid_centering():
-    """ intentionally invalid CENTERING option to test the error message part of the code. 
+    """ intentionally invalid CENTERING option to test the error message part of the code.
     """
     try:
         import pytest
@@ -526,17 +526,16 @@ def test_parity_MFT_forward_inverse(display = False):
 
 
     """
-    from .test_core import ParityTestAperture
 
     # set up optical system with 2 pupil planes and 2 image planes
 
     # use the same exact image plane sampling as in the FFT case
     # This is a bit slower but ensures quantitative agreement.
 
-    pixscale = 0.03437746770784939 
+    pixscale = 0.03437746770784939
     npix=2048
     sys = poppy_core.OpticalSystem()
-    sys.addPupil(ParityTestAperture())
+    sys.addPupil(optics.ParityTestAperture())
     sys.addDetector(pixelscale=pixscale, fov_pixels=npix)
     sys.addPupil()
     sys.addDetector(pixelscale=pixscale, fov_pixels=npix)
@@ -546,16 +545,20 @@ def test_parity_MFT_forward_inverse(display = False):
     # the wavefronts are padded by 0s. With the current API the most convenient
     # way to ensure we get unpadded versions is via the asFITS function.
     p0 = planes[0].asFITS(what='intensity', includepadding=False)
+    p1 = planes[1].asFITS(what='intensity', includepadding=False)
     p2 = planes[2].asFITS(what='intensity', includepadding=False)
 
     # for checking the overall parity it's sufficient to check the intensity.
-    # we can have arbitrarily large differences in phase for regions with 
-    # intensity =0, so don't check the complex field or phase here. 
+    # we can have arbitrarily large differences in phase for regions with
+    # intensity =0, so don't check the complex field or phase here.
 
 
     absdiff = (np.abs(p0[0].data - p2[0].data))
     maxabsdiff = np.max(absdiff)
-    assert (maxabsdiff < 1e-10)
+    # TODO this test could be more stringent if we used a better aperture
+    # which is band-limited in the FFT so you don't get all the 
+    # Gibbs effect ringing after these two FFTs.
+    assert (maxabsdiff < 1e-6)
 
     if display:
         nplanes = len(planes)
@@ -577,8 +580,7 @@ def test_MFT_FFT_equivalence(display=False, displaycrop=None):
 
     centering='FFTSTYLE' # needed if you want near-exact agreement!
 
-    from poppy.tests.test_core import ParityTestAperture
-    imgin = ParityTestAperture().sample(wavelength=1e-6, npix=256)
+    imgin = optics.ParityTestAperture().sample(wavelength=1e-6, npix=256)
 
     npix = imgin.shape
     nlamD = np.asarray(imgin.shape)
@@ -646,16 +648,15 @@ def test_MFT_FFT_equivalence_in_OpticalSystem(display=False):
     # Thus in order to get an exact equivalence, we have to set up our
     # OpticalSystem so that it, very unusually, uses an odd size for
     # its input wavefront. The easiest way to do this is to discretize
-    # an AnalyticOpticalElement onto a specific grid. 
+    # an AnalyticOpticalElement onto a specific grid.
 
-    from poppy.tests.test_core import ParityTestAperture
-    fits511 = ParityTestAperture().toFITS('test.fits', wavelength=1e-6, npix=511)
+    fits511 = optics.ParityTestAperture().toFITS('test.fits', wavelength=1e-6, npix=511)
     pup511 = poppy_core.FITSOpticalElement(transmission=fits511)
 
 
     # set up simple optical system that will just FFT
     fftsys = poppy_core.OpticalSystem(oversample=1)
-    fftsys.addPupil(pup511) #ParityTestAperture())
+    fftsys.addPupil(pup511)
     fftsys.addImage()
 
     fftpsf, fftplanes = fftsys.calcPSF(display=False, return_intermediates=True)
@@ -663,7 +664,7 @@ def test_MFT_FFT_equivalence_in_OpticalSystem(display=False):
     # set up equivalent using an MFT, tuned to get the exact same scale
     # for the image plane
     mftsys = poppy_core.OpticalSystem(oversample=1)
-    mftsys.addPupil(pup511) #ParityTestAperture())
+    mftsys.addPupil(pup511)
     mftsys.addDetector(pixelscale=fftplanes[1].pixelscale , fov_pixels=fftplanes[1].shape, oversample=1) #, offset=(pixscale/2, pixscale/2))
 
     mftpsf, mftplanes = mftsys.calcPSF(display=False, return_intermediates=True)

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import matplotlib.pyplot as pl
 import numpy as np
 import astropy.io.fits as fits
+import astropy.units as u
 
 from .. import poppy_core
 from .. import optics
@@ -418,7 +419,8 @@ def test_GaussianAperture(display=False):
             self.planetype=poppy_core.PlaneType.pupil
             self.pixelscale = 0.5
         def coordinates(self):
-            return (np.asarray([0,0.5, 0.0, ga.w, 0.0]), np.asarray([0, 0, 0.5, 0, -ga.w ]))
+            w = ga.w.to(u.meter).value
+            return (np.asarray([0,0.5, 0.0, w, 0.0]), np.asarray([0, 0, 0.5, 0, -w ]))
 
     trickwave = mock_wavefront()
     trickwave *= ga

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -95,7 +95,7 @@ def test_SquareFieldStop():
 
 
 def test_BarOcculter():
-    optic= optics.BarOcculter(width=1, angle=0)
+    optic= optics.BarOcculter(width=1, rotation=0)
     wave = poppy_core.Wavefront(npix=100, pixelscale=0.1, wavelength=1e-6) # 10x10 arcsec square
 
     wave*= optic

--- a/poppy/tests/test_wavefront.py
+++ b/poppy/tests/test_wavefront.py
@@ -1,12 +1,13 @@
 
-from .. import poppy_core 
+from .. import poppy_core
 import numpy as np
 import astropy.io.fits as fits
 from .test_core import check_wavefront
+import astropy.units as u
 
 
 
-wavelength=1e-6
+wavelength=1e-6*u.m
 
 
 def test_wavefront_in_pixels():
@@ -40,9 +41,9 @@ def test_wavefront_str():
     wave = poppy_core.Wavefront(npix=100, wavelength=1e-6)
     string_representation = str(wave)
     assert string_representation =="""Wavefront:
-        wavelength = 1.000000 microns
-        shape = (100,100)
-        sampling = 0.080000 meters/pixel"""
+        wavelength = 1.0 micron
+        shape = (100, 100)
+        sampling = 0.08 m / pix"""
 
 def test_wavefront_copy():
     # test copy

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -989,11 +989,11 @@ class BackCompatibleQuantityInput(object):
         This is a *variant* of the quantity_input decorator provided by astropy;
         the difference is the handling of bare input numbers without units.
 
-		When given such an input, this function will silently & without complaint apply
-		the specified unit as a default. The astropy version will raise a ValueError
-		that it was expecting a Quantity.  The benefit is this approach allows back
-		compatibility with functions originally written to accept floating point values
-		implicitly in meters.
+        When given such an input, this function will silently & without complaint apply
+        the specified unit as a default. The astropy version will raise a ValueError
+        that it was expecting a Quantity.  The benefit is this approach allows back
+        compatibility with functions originally written to accept floating point values
+        implicitly in meters.
 
         Unit specifications can be provided as keyword arguments to the decorator,
         or by using Python 3's function annotation syntax. Arguments to the decorator

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1053,7 +1053,7 @@ class BackCompatibleQuantityInput(object):
 
         # Define a new function to return in place of the wrapped one
         @wraps(wrapped_function)
-        def wrapper(*func_args, **func_kwargs):
+        def unit_check_wrapper(*func_args, **func_kwargs):
             # Bind the arguments to our new function to the signature of the original.
             bound_args = wrapped_signature.bind(*func_args, **func_kwargs)
 
@@ -1122,7 +1122,7 @@ class BackCompatibleQuantityInput(object):
                 #print("KWArgs: {}".format(bound_args.kwargs))
                 return wrapped_function(*bound_args.args, **bound_args.kwargs)
 
-        return wrapper
+        return unit_check_wrapper
 
 quantity_input = BackCompatibleQuantityInput.as_decorator
 

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -297,5 +297,5 @@ class SineWaveWFE(WavefrontError):
                 (x / self.sine_spatial_freq + self.sine_phase_offset))
 
         if units == 'waves':
-            opd /= (wave.wavelength.to(u.meter).value)
+            opd /= wave.wavelength.to(u.meter).value
         return opd

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -16,6 +16,7 @@ from __future__ import (absolute_import, division, print_function,
 import collections
 from functools import wraps
 import numpy as np
+import astropy.units as u
 
 from .optics import AnalyticOpticalElement, CircularAperture
 from .poppy_core import Wavefront, _PUPIL
@@ -81,7 +82,7 @@ class WavefrontError(AnalyticOpticalElement):
             a wavefront wavelength in meters
         """
         opd_map = self.get_opd(wave, units='meters')
-        opd_as_phase = 2 * np.pi * opd_map / wave.wavelength
+        opd_as_phase = 2 * np.pi * opd_map / (wave.wavelength.to(u.meter).value)
         wfe_phasor = np.exp(1.j * opd_as_phase)
         return wfe_phasor
 
@@ -234,12 +235,14 @@ class ZernikeWFE(WavefrontError):
         # implicitly also a circular aperture:
         aperture_intensity = self.circular_aperture.getPhasor(wave)
 
+        pixelscale_m = wave.pixelscale.to(u.meter/u.pixel).value
+
         combined_zernikes = np.zeros(wave.shape, dtype=np.float64)
         for j, k in enumerate(self.coefficients, start=1):
             combined_zernikes += k * zernike.cached_zernike1(
                 j,
                 wave.shape,
-                wave.pixelscale,
+                pixelscale_m,
                 self.radius,
                 outside=0.0,
                 noll_normalize=True
@@ -294,5 +297,5 @@ class SineWaveWFE(WavefrontError):
                 (x / self.sine_spatial_freq + self.sine_phase_offset))
 
         if units == 'waves':
-            opd /= wave.wavelength
+            opd /= (wave.wavelength.to(u.meter).value)
         return opd


### PR DESCRIPTION
This addresses #145 by making lots of things into astropy Quantities, primarily wavelengths and pixel scales. As a result we can now explicitly specify wavelengths in meters or microns or whatever and things will Just Work. 

As proposed in #145, a decorator is added to ``utils`` that allows back-compatible function arguments given as floating point values to be automatically converted to astropy Quantity lengths in meters. You can give other units explicitly as e.g. ``wavelength=2*u.micron``.   (This decorator is currently named "quantity_input", the same as the related but different function provided by astropy itself. I couldn't think of any better name apart from monstrosities like e.g. ``@back_compatible_quantity_input_with_slightly_different_behavior_than_the_astropy_one``; please feel free to suggest improvements)

In any case, this decorator is then applied liberally throughout poppy_core, fresnel, and optics.py. Many string formatting and FITS header writing code lines had to be fixed. I added various casts to floating point values in meters where needed, which is awkward and a bit convoluted but is needed given that not absolutely everything uses Quantities yet. 