### PR TITLE
Fix setup.py ConfigParser import (per astropy/package-template#172)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,12 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
I'm not sure why we haven't encountered this before, but I just ran into it when installing POPPY in a fresh/clean conda Python 3.5 environment. (It might be a 3.4 to 3.5 change?)

(Fixed upstream in astropy/package-template#172)