### PR TITLE
Fix #171: improper formatting of unit-y wavelength quantities

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1030,8 +1030,10 @@ class FresnelOpticalSystem(OpticalSystem):
         inwave = FresnelWavefront(self.pupil_diameter / 2, wavelength=wavelength,
                                   npix=self.npix, oversample=oversample)
         _log.debug(
-            "Creating input wavefront with wavelength={0:e} microns, npix={1}, pixel scale={2:f} meters/pixel".format(
-                wavelength * 1e6, self.npix, self.pupil_diameter / self.npix))
+            "Creating input wavefront with wavelength={0} microns,"
+            "npix={1}, pixel scale={2}".format(
+                wavelength.to(u.micron).value, self.npix, self.pupil_diameter / (self.npix * u.pixel)
+        ))
         return inwave
 
     @utils.quantity_input(wavelength=u.meter)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1522,8 +1522,11 @@ class OpticalSystem(object):
         tstart = time.time()
         if source is not None:
             wavelength = source['wavelengths']
-            weight=source['weights']
-            if not isinstance(wavelength, u.Quantity): wavelength *= u.meter
+            weight = source['weights']
+
+            # Make sure the wavelength is unit-y
+            if not isinstance(wavelength, u.Quantity):
+                wavelength = np.asarray(wavelength) * u.meter
 
         # ensure wavelength is a quantity which is iterable:
         # (the check for a quantity of type length is applied in the decorator)
@@ -2079,10 +2082,21 @@ class MatrixFTCoronagraph(OpticalSystem):
                 intermediate_wfs.append(wavefront.copy())
 
             if display_intermediates:
-                if conf.enable_speed_tests: t0 = time.time()
-                title = None if current_plane_index > 1 else "propagating $\lambda=$ %.3f $\mu$m" % (wavelength*1e6)
-                wavefront.display(what='best',nrows=len(self.planes),row=current_plane_index, colorbar=False, title=title)
-                #plt.title("propagating $\lambda=$ %.3f $\mu$m" % (wavelength*1e6))
+                if conf.enable_speed_tests:
+                    t0 = time.time()
+
+                if current_plane_index > 1:
+                    title = None
+                else:
+                    title = "propagating $\lambda=$ {:.3} $\mu$m".format(wavelength.to(u.micron).value)
+
+                wavefront.display(
+                    what='best',
+                    nrows=len(self.planes),
+                    row=current_plane_index,
+                    colorbar=False,
+                    title=title
+                )
 
                 if conf.enable_speed_tests:
                     t1 = time.time()


### PR DESCRIPTION
I did a pass through looking for places where wavelength was being suspiciously multiplied by numerical constants and caught another instance that needs fixing.