### PR TITLE
Wavefront class display() method: fix the handling of user-specified vmin, vmax arguments for phase map plot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Code by Marshall Perrin, Joseph Long, Ewan Douglas, with additional
 contributions from Anand Sivaramakrishnan, Remi Soummer, Christine Slocum,
 and others on the Astropy team.
 
+test edit
 
 
 Projects using poppy

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,6 @@ Code by Marshall Perrin, Joseph Long, Ewan Douglas, with additional
 contributions from Anand Sivaramakrishnan, Remi Soummer, Christine Slocum,
 and others on the Astropy team.
 
-test edit
-
 
 Projects using poppy
 ----------------------------

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ contributions from Anand Sivaramakrishnan, Remi Soummer, Christine Slocum,
 and others on the Astropy team.
 
 
+
 Projects using poppy
 ----------------------------
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -434,10 +434,16 @@ class Wavefront(object):
 
         # prepare color maps and normalizations for intensity and phase
         if vmax is None:
-            vmax = intens.max()
+            if what == 'phase':
+               vmax = 0.25
+            else:
+               vmax = intens.max()
         if scale == 'linear':
             if vmin is None:
-                vmin = 0
+                if what == 'phase':
+                    vmin = -0.25
+                else:
+                    vmin = 0
             norm_inten = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
             cmap_inten = getattr(matplotlib.cm, conf.cmap_pupil_intensity)
             cmap_inten.set_bad('0.0')
@@ -449,7 +455,7 @@ class Wavefront(object):
             cmap_inten.set_bad(cmap_inten(0))
         cmap_phase = getattr(matplotlib.cm, conf.cmap_diverging)
         cmap_phase.set_bad('0.3')
-        norm_phase = matplotlib.colors.Normalize(vmin=-0.25, vmax=0.25)
+        norm_phase = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
 
         # now display the chosen selection..
         if what == 'intensity':

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -337,7 +337,9 @@ class Wavefront(object):
         row : int
             Which row to display this one in?
         vmin, vmax : floats
-            min and maximum values to display.
+            min and maximum values to display. When left unspecified, these default 
+            to [0, intens.max()] for intensity plots and [-0.25, 0.25] waves 
+            for phase plots. 
         scale : string
             'log' or 'linear', to define the desired display scale type for
             intensity. Default is log for image planes, linear otherwise.


### PR DESCRIPTION
Currently, when you display a phase map, user-specified vmin and vmax values are ignored. I added a few lines of logic so that when the user provides parameters that are not None, they override the defaults (-0.25, 0.25).