### PR TITLE
Update .travis.yml and fix the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,15 @@ install:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
 
 script:
-   - python setup.py $SETUP_CMD
+    - python setup.py $SETUP_CMD
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='poppy/tests/coveragerc'; fi
+
+notifications:
+    email:
+        - mperrin@stsci.edu
+        - jlong@stsci.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ matrix:
         # Do a coverage test in Python 3.
         - python: 3.5
           env: SETUP_CMD='test --coverage'
+
         # Check for sphinx doc build errors
-        - python: 3.5
+        - python: 2.7
           env: SETUP_CMD='build_sphinx'
 
         # Try all supported Python versions with the latest NumPy
@@ -50,7 +51,7 @@ matrix:
 
         # Test one previous version of NumPy
         - python: 2.7
-          env: NUMPY_VERSION=OLDER_NUMPY_VERSION ASTROPY_VERSION=stable SETUP_CMD='test'
+          env: NUMPY_VERSION=$OLDER_NUMPY_VERSION ASTROPY_VERSION=stable SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,24 @@ sudo: false
 
 python:
     - 2.7
-    # - 3.3
     - 3.5
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
+
+addons:
+    apt:
+        packages:
+            # Used for Spginx 
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.11
         - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
+        - CONDA_INSTALL='conda install --yes'
         - PIP_INSTALL='pip install'
     matrix:
         - SETUP_CMD='egg_info'
@@ -25,16 +32,14 @@ matrix:
         # Do a coverage test in Python 2.
         #- python: 2.7
         #  env: SETUP_CMD='test --coverage'
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time. 
-        # Update: ignore warnings, just check for errors
+
+        # Check for sphinx doc build errors
         - python: 2.7
           env: SETUP_CMD='build_sphinx'
 
-        # Try all python versions with the latest numpy
+        # Try all support Python versions with the latest NumPy
+        # and other dependencies
         - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.4
           env: SETUP_CMD='test'
         - python: 3.5
           env: SETUP_CMD='test'
@@ -43,42 +48,31 @@ matrix:
         # Try Astropy development version
         - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        # - python: 3.3
-        #   env: ASTROPY_VERSION=development SETUP_CMD='test'
 
-        # Try older numpy version
-        # Use (temporarily?) the dev astropy to work around the issue in 
-        # https://github.com/mperrin/poppy/issues/87 
-        # https://github.com/astropy/astropy-helpers/issues/73#issuecomment-72558556
+        # Test one previous version of NumPy
         - python: 2.7
-          env: NUMPY_VERSION=1.8 ASTROPY_VERSION=development SETUP_CMD='test'
-    allow_failures:
+          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
         - python: 3.5
-
-addons:
-    apt:
-        packages:
-        - graphviz                  # actually only needed for build_spinx
-        - texlive-latex-extra       # actually only needed for build_spinx
-        - dvipng                    # actually only needed for build_spinx
-
+          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
 
 before_install:
 
     # Use utf8 encoding. Should be default, but this is insurance against
     # future changes
     - export PYTHONIOENCODING=UTF8
+    # Prefer Agg backend in case PyPlot is imported
+    # (see http://matplotlib.org/faq/environment_variables_faq.html)
+    - export MPLBACKEND=Agg
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda update --yes conda
-    - conda update --all -y  # added to try debugging issue #159 with Travis
 
 install:
 
     # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
+    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
     - source activate test
 
     # CORE DEPENDENCIES


### PR DESCRIPTION
I understand there is a new way to write `.travis.yml` files in Astropy's package template, but I haven't yet gotten it to work. This fixes the file we had so at least the build runs.