### PR TITLE
Fix for non-integer indexing in Numpy >= 1.12.0

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2273,10 +2273,8 @@ class OpticalElement(object):
                 lx,ly=resampled_amplitude.shape
                 #crop down to match size of wavefront:
                 lx_w,ly_w = wave.amplitude.shape
-
-                # explicit cast to int fixes index errors in Numpy >= 1.12.0
-                border_x = int(np.abs(np.floor((lx-lx_w)/2)))
-                border_y = int(np.abs(np.floor((ly-ly_w)/2)))
+                border_x = np.abs(lx-lx_w) // 2
+                border_y = np.abs(ly-ly_w) // 2
                 if (self.pixelscale*self.amplitude.shape[0] < wave.pixelscale*wave.amplitude.shape[0]) or (self.pixelscale*self.amplitude.shape[1] < wave.pixelscale*wave.amplitude.shape[0]):
                     #raise ValueError("Optic is smaller than input wavefront")
                     _log.warn("Optic"+str(np.shape(resampled_opd))+" is smaller than input wavefront"+str([lx_w,ly_w])+", will attempt to zero-pad the rescaled array")

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2273,8 +2273,10 @@ class OpticalElement(object):
                 lx,ly=resampled_amplitude.shape
                 #crop down to match size of wavefront:
                 lx_w,ly_w = wave.amplitude.shape
-                border_x = np.abs(np.floor((lx-lx_w)/2))
-                border_y = np.abs(np.floor((ly-ly_w)/2))
+
+                # explicit cast to int fixes index errors in Numpy >= 1.12.0
+                border_x = int(np.abs(np.floor((lx-lx_w)/2)))
+                border_y = int(np.abs(np.floor((ly-ly_w)/2)))
                 if (self.pixelscale*self.amplitude.shape[0] < wave.pixelscale*wave.amplitude.shape[0]) or (self.pixelscale*self.amplitude.shape[1] < wave.pixelscale*wave.amplitude.shape[0]):
                     #raise ValueError("Optic is smaller than input wavefront")
                     _log.warn("Optic"+str(np.shape(resampled_opd))+" is smaller than input wavefront"+str([lx_w,ly_w])+", will attempt to zero-pad the rescaled array")

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -145,7 +145,7 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
         gw.display('both',colorbar=True)
         plt.figure(figsize=(12,6))
 
-        plt.plot(x[0,:], inten[inten.shape[1]/2,:], label='POPPY')
+        plt.plot(x[0,:], inten[inten.shape[1]//2,:], label='POPPY')
         plt.title("z={:0.2e} , compare to Anderson and Enmark fig.6.15".format(z))
         plt.gca().set_xlim(-1, 1)
         plt.text(0.1,2, "Max value: {0:.4f}\nExpected:   {1:.4f}".format(np.max(inten), max(proper_y)))
@@ -175,7 +175,8 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
     # due to the minor asymmetry from having the FFT center pixel
     # not precisely centered in the array.)
 
-    cen = inten.shape[0]/2
+    # integer division // fixes index errors in Numpy >= 1.12.0
+    cen = inten.shape[0]//2
     cutsize=10
     center_cut_x = inten[cen-cutsize:cen+cutsize+1, cen]
     assert(np.all((center_cut_x- center_cut_x[::-1])/center_cut_x < 0.001))
@@ -350,7 +351,8 @@ def test_fresnel_optical_system_Hubble(display=False):
                               shape=(128,128), pixelscale=psf[0].header['PIXELSCL'],
                              center=(64,64))
 
-    centerpix = hst.npix / hst.beam_ratio / 2
+    # explicit cast to integer fixes index errors in Numpy >= 1.12.0
+    centerpix = int(hst.npix / hst.beam_ratio / 2)
     cutout = psf[0].data[centerpix-64:centerpix+64, centerpix-64:centerpix+64] / psf[0].data[centerpix,centerpix]
     assert( np.abs(cutout-airy).max() < 1e-4 )
 

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -175,7 +175,6 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
     # due to the minor asymmetry from having the FFT center pixel
     # not precisely centered in the array.)
 
-    # integer division // fixes index errors in Numpy >= 1.12.0
     cen = inten.shape[0]//2
     cutsize=10
     center_cut_x = inten[cen-cutsize:cen+cutsize+1, cen]
@@ -351,7 +350,6 @@ def test_fresnel_optical_system_Hubble(display=False):
                               shape=(128,128), pixelscale=psf[0].header['PIXELSCL'],
                              center=(64,64))
 
-    # explicit cast to integer fixes index errors in Numpy >= 1.12.0
     centerpix = int(hst.npix / hst.beam_ratio / 2)
     cutout = psf[0].data[centerpix-64:centerpix+64, centerpix-64:centerpix+64] / psf[0].data[centerpix,centerpix]
     assert( np.abs(cutout-airy).max() < 1e-4 )

--- a/poppy/tests/test_matrixDFT.py
+++ b/poppy/tests/test_matrixDFT.py
@@ -341,8 +341,9 @@ def test_DFT_rect_fov_sampling(fov_npix = (500,1000), pixelscale=0.03, display=F
 
     plane=1
 
-    cut_h = intermediates[plane].intensity[fov_npix[0]/2,                           fov_npix[1]/2-delta:fov_npix[1]/2+delta]
-    cut_v = intermediates[plane].intensity[fov_npix[0]/2-delta:fov_npix[0]/2+delta, fov_npix[1]/2]
+    # integer division // fixes index errors in Numpy >= 1.12.0
+    cut_h = intermediates[plane].intensity[fov_npix[0]//2, fov_npix[1]//2-delta:fov_npix[1]//2+delta]
+    cut_v = intermediates[plane].intensity[fov_npix[0]//2-delta:fov_npix[0]//2+delta, fov_npix[1]//2]
 
     assert(np.all(np.abs(cut_h-cut_v) < 1e-12))
 

--- a/poppy/tests/test_matrixDFT.py
+++ b/poppy/tests/test_matrixDFT.py
@@ -341,7 +341,6 @@ def test_DFT_rect_fov_sampling(fov_npix = (500,1000), pixelscale=0.03, display=F
 
     plane=1
 
-    # integer division // fixes index errors in Numpy >= 1.12.0
     cut_h = intermediates[plane].intensity[fov_npix[0]//2, fov_npix[1]//2-delta:fov_npix[1]//2+delta]
     cut_v = intermediates[plane].intensity[fov_npix[0]//2-delta:fov_npix[0]//2+delta, fov_npix[1]//2]
 

--- a/poppy/tests/test_nonsquare.py
+++ b/poppy/tests/test_nonsquare.py
@@ -55,10 +55,7 @@ def test_nonsquare_detector_values(oversample=1, pixelscale=0.010, wavelength=1e
 
         #pl.figure(2)
         psf0 = results[0]
-        print(psf0)
         bx=10
-
-        # integer division // fixes index errors in Numpy >= 1.12.0
         ceny = psf0.shape[0]//2
         cenx = psf0.shape[1]//2
 
@@ -79,7 +76,6 @@ def test_nonsquare_detector_values(oversample=1, pixelscale=0.010, wavelength=1e
 
             #pl.subplot(1, len(fovs_to_test),  i+1)
 
-            # integer division // fixes index errors in Numpy >= 1.12.0
             ceny = thispsf.shape[0]//2
             cenx = thispsf.shape[1]//2
 

--- a/poppy/tests/test_nonsquare.py
+++ b/poppy/tests/test_nonsquare.py
@@ -55,9 +55,12 @@ def test_nonsquare_detector_values(oversample=1, pixelscale=0.010, wavelength=1e
 
         #pl.figure(2)
         psf0 = results[0]
+        print(psf0)
         bx=10
-        ceny = psf0.shape[0]/2
-        cenx = psf0.shape[1]/2
+
+        # integer division // fixes index errors in Numpy >= 1.12.0
+        ceny = psf0.shape[0]//2
+        cenx = psf0.shape[1]//2
 
         cut0 = psf0[ceny-bx:ceny+bx, cenx-bx:cenx+bx]
 
@@ -76,8 +79,9 @@ def test_nonsquare_detector_values(oversample=1, pixelscale=0.010, wavelength=1e
 
             #pl.subplot(1, len(fovs_to_test),  i+1)
 
-            ceny = thispsf.shape[0]/2
-            cenx = thispsf.shape[1]/2
+            # integer division // fixes index errors in Numpy >= 1.12.0
+            ceny = thispsf.shape[0]//2
+            cenx = thispsf.shape[1]//2
 
             thiscut = thispsf[ceny-bx:ceny+bx, cenx-bx:cenx+bx]
             #pl.imshow(np.log10(thiscut))

--- a/poppy/tests/test_wavefront.py
+++ b/poppy/tests/test_wavefront.py
@@ -77,7 +77,6 @@ def test_wavefront_inversion():
     # test the inversion
     wave_inv = wave.copy()
     wave_inv.invert()
-    # integer division // fixes index errors in Numpy >= 1.12.0
     assert np.allclose(wave0.wavefront[npix//2], wave_inv.wavefront[npix//2, ::-1])
     assert np.allclose(wave0.wavefront[:, npix//2], wave_inv.wavefront[::-1, npix//2])
 

--- a/poppy/tests/test_wavefront.py
+++ b/poppy/tests/test_wavefront.py
@@ -77,8 +77,9 @@ def test_wavefront_inversion():
     # test the inversion
     wave_inv = wave.copy()
     wave_inv.invert()
-    assert np.allclose(wave0.wavefront[npix/2], wave_inv.wavefront[npix/2, ::-1])
-    assert np.allclose(wave0.wavefront[:, npix/2], wave_inv.wavefront[::-1, npix/2])
+    # integer division // fixes index errors in Numpy >= 1.12.0
+    assert np.allclose(wave0.wavefront[npix//2], wave_inv.wavefront[npix//2, ::-1])
+    assert np.allclose(wave0.wavefront[:, npix//2], wave_inv.wavefront[::-1, npix//2])
 
 
 def test_wavefront_asFITS():


### PR DESCRIPTION
As of version 1.12.0, NumPy no longer implicitly casts non-integers to integers for array indexing and instead raises an `IndexError`. See the [Numpy Release Notes](https://docs.scipy.org/doc/numpy-dev/release.html#id6) for details.

A couple of lines in poppy_core.py and the test scripts required either explicit integer casting or integer division with the `//` operator for compatibility with NumPy >= 1.12.0.

The Poppy test suite is now passing on my machine with Python 3.5.2 and 2.7.13 and Numpy 1.12.0 with these fixes. You may want to add a build with Numpy 1.12.0 to Travis to verify that things work on your end.