### PR TITLE
ignore nan values in radial standard deviations

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2368,7 +2368,6 @@ class OpticalElement(object):
                 units = "\n".join(textwrap.wrap(units,20))
 
         if self.pixelscale is not None:
-            # TODO handle units better here for pupil vs. image planes? meters/pix vs arcsec/pix
             if self.pixelscale.decompose().unit ==u.m/u.pix:
                 halfsize = self.pixelscale.to(u.m/u.pix).value * self.amplitude.shape[0] / 2
             elif self.pixelscale.decompose().unit == u.radian/u.pix:

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2369,7 +2369,13 @@ class OpticalElement(object):
 
         if self.pixelscale is not None:
             # TODO handle units better here for pupil vs. image planes? meters/pix vs arcsec/pix
-            halfsize = self.pixelscale.value * self.amplitude.shape[0] / 2
+            if self.pixelscale.decompose().unit ==u.m/u.pix:
+                halfsize = self.pixelscale.to(u.m/u.pix).value * self.amplitude.shape[0] / 2
+            elif self.pixelscale.decompose().unit == u.radian/u.pix:
+                halfsize = self.pixelscale.to(u.arcsec/u.pix).value * self.amplitude.shape[0] / 2
+            else:
+                halfsize = self.pixelscale.value * self.amplitude.shape[0] / 2
+                _log.warn("Using pixelscale value without conversion, units not recognized.") 
             _log.debug("Display pixel scale = {} ".format(self.pixelscale))
         else:
             # TODO not sure this code path ever gets used - since pixelscale is set temporarily

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -571,7 +571,8 @@ def radial_profile(HDUlist_or_filename=None, ext=0, EE=False, center=None, stdde
     deltar = ri[1:] - ri[:-1]  # assume all radii represented (more work if not)
     rind = np.where(deltar)[0]
     nr = rind[1:] - rind[:-1]  # number in radius bin
-    csim = np.cumsum(sim, dtype=float)  # cumulative sum to figure out sums for each bin
+    csim = np.nan_to_num(sim).cumsum(dtype=float)   # cumulative sum to figure out sums for each bin
+    #np.nancumsum is implemented in >1.12
     tbin = csim[rind[1:]] - csim[rind[:-1]]  # sum for image values in radius bins
     radialprofile = tbin / nr
 
@@ -595,7 +596,7 @@ def radial_profile(HDUlist_or_filename=None, ext=0, EE=False, center=None, stdde
             else:
                 wg = np.where((r_pix >= (radius - binsize / 2)) & (r_pix < (radius + binsize / 2)))
                 # wg = np.where( (r >= rr[i-1]) &  (r <rr[i] )))
-            stddevs[i] = image[wg].std()
+            stddevs[i] = np.nanstd(image[wg])
         return rr, stddevs
 
     if not EE:

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -509,7 +509,8 @@ def radial_profile(HDUlist_or_filename=None, ext=0, EE=False, center=None, stdde
     Parameters
     ----------
     HDUlist_or_filename : string
-        what it sounds like.
+        FITS HDUList object or path to a FITS file. 
+        NaN values in the FITS data array are treated as masked and ignored in computing bin statistics.
     ext : int
         Extension in FITS file
     EE : bool


### PR DESCRIPTION
This change ignores NaN values passed to radial_profile(), effectively ignoring (treating as zero) in the cumulative sum and ignoring in the calculation of the standard deviation. 