### PR TITLE
Fix propagate_direct in fresnel wavefront

### DIFF
--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -410,7 +410,7 @@ def test_fresnel_propagate_direct_forward_and_back():
     wf = fresnel.FresnelWavefront(
         0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
     )
-    wf *= poppy_core.CircularAperture(radius=0.5)
+    wf *= optics.CircularAperture(radius=0.5)
     z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
     start = wf.wavefront.copy()
     wf.propagate_direct(z)
@@ -424,7 +424,7 @@ def test_fresnel_propagate_direct_back_and_forward():
     wf = fresnel.FresnelWavefront(
         0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
     )
-    wf *= poppy_core.CircularAperture(radius=0.5)
+    wf *= optics.CircularAperture(radius=0.5)
     z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
     start = wf.wavefront.copy()
     wf.propagate_direct(-z)
@@ -438,7 +438,7 @@ def test_fresnel_propagate_direct_2forward_and_back():
     wf = fresnel.FresnelWavefront(
         0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
     )
-    wf *= poppy_core.CircularAperture(radius=0.5)
+    wf *= optics.CircularAperture(radius=0.5)
     z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
 
     wf.propagate_direct(z)
@@ -446,18 +446,3 @@ def test_fresnel_propagate_direct_2forward_and_back():
     wf.propagate_direct(z)
     wf.propagate_direct(-z)
     np.testing.assert_almost_equal(wf.wavefront, start)
-
-
-def test_fresnel_propagate_direct_ptp_compare():
-    npix = 1024
-    wavelen = 2200 * u.nm
-    wf1 = fresnel.FresnelWavefront(
-        0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
-    )
-    wf1 *= poppy_core.CircularAperture(radius=0.5)
-    wf2 = wf1.copy()
-    z = ((wf1.pixelscale * u.pix) ** 2 * wf1.n / (2200 * u.nm)).to(u.m)
-
-    wf1.propagate_direct(z)
-    wf2._propagate_ptp(z)
-    np.testing.assert_almost_equal(wf1.wavefront, wf2.wavefront)

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -404,4 +404,60 @@ def test_fresnel_FITS_Optical_element(tmpdir, display=False):
     assert np.abs(psf_with_astigmatism[0].data.max() - 0.00178667) < 1e-5, "PSF peak pixel is not as expected"
 
 
+def test_fresnel_propagate_direct_forward_and_back():
+    npix = 1024
+    wavelen = 2200 * u.nm
+    wf = fresnel.FresnelWavefront(
+        0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
+    )
+    wf *= poppy_core.CircularAperture(radius=0.5)
+    z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
+    start = wf.wavefront.copy()
+    wf.propagate_direct(z)
+    wf.propagate_direct(-z)
+    np.testing.assert_almost_equal(wf.wavefront, start)
 
+
+def test_fresnel_propagate_direct_back_and_forward():
+    npix = 1024
+    wavelen = 2200 * u.nm
+    wf = fresnel.FresnelWavefront(
+        0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
+    )
+    wf *= poppy_core.CircularAperture(radius=0.5)
+    z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
+    start = wf.wavefront.copy()
+    wf.propagate_direct(-z)
+    wf.propagate_direct(z)
+    np.testing.assert_almost_equal(wf.wavefront, start)
+
+
+def test_fresnel_propagate_direct_2forward_and_back():
+    npix = 1024
+    wavelen = 2200 * u.nm
+    wf = fresnel.FresnelWavefront(
+        0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
+    )
+    wf *= poppy_core.CircularAperture(radius=0.5)
+    z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
+
+    wf.propagate_direct(z)
+    start = wf.wavefront.copy()
+    wf.propagate_direct(z)
+    wf.propagate_direct(-z)
+    np.testing.assert_almost_equal(wf.wavefront, start)
+
+
+def test_fresnel_propagate_direct_ptp_compare():
+    npix = 1024
+    wavelen = 2200 * u.nm
+    wf1 = fresnel.FresnelWavefront(
+        0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
+    )
+    wf1 *= poppy_core.CircularAperture(radius=0.5)
+    wf2 = wf1.copy()
+    z = ((wf1.pixelscale * u.pix) ** 2 * wf1.n / (2200 * u.nm)).to(u.m)
+
+    wf1.propagate_direct(z)
+    wf2._propagate_ptp(z)
+    np.testing.assert_almost_equal(wf1.wavefront, wf2.wavefront)


### PR DESCRIPTION
A fix to `propagate_direct`. 
=====================

I have finally found a way to fix direct propagation [(issue);](https://github.com/mperrin/poppy/issues/216) the main problem was improper use of `fftshift`s. Based on [Khare 2015](http://eu.wiley.com/WileyCDA/WileyTitle/productCd-1118900340.html) a wavefront has to be shifted **both** before and after performing fft:

> [...] the appropriate usage of functions for the inverse FFT operation is
> similarly: fftshift(ifft2(ifftshift(...))). (page 72)

And then he even adds: 

> These topics have been discussed here since they appear to be common sources of errors 

My implementation (which works) proves his point. 

In addition to proper shifting I fixed `quadphase_2nd` (added `k`).

Another small thing was to assure that `pixelscale` is always positive (simply by making `abs(z)`) and updating `self.z`.

Here are some examples: 
```
import poppy
import astropy.units as u 
npix = 1024
wavelen = 2200 * u.nm
wf = poppy.FresnelWavefront(
    0.5 * u.m, wavelength=wavelen, npix=npix, oversample=4
)
wf *= poppy.CircularAperture(radius=0.5)
z = ((wf.pixelscale * u.pix) ** 2 * wf.n / (2200 * u.nm)).to(u.m)
wf.display('both')
wf.propagate_direct(z)
wf.display('both')
wf.propagate_direct(-z)
wf.display('both')
```

START:
![start](https://cloud.githubusercontent.com/assets/22051728/24723618/87b0cbb0-1a48-11e7-92c3-a357fc17a58a.png)
Propagated to z:
![to_z](https://cloud.githubusercontent.com/assets/22051728/24723629/8fe473ae-1a48-11e7-9762-06442f956c88.png)
Propagated back to 0:
![back](https://cloud.githubusercontent.com/assets/22051728/24723649/9b61bcbe-1a48-11e7-86ea-acaddb33d3e1.png)



