### PR TITLE
fix documentation of divergence angle

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -307,11 +307,11 @@ class FresnelWavefront(Wavefront):
     @property
     def divergence(self):
         """
-        Full-angle divergence of the gaussian beam
+        Half-angle divergence of the gaussian beam
 
-        I.e. twice the angle between the optical axis and the beam radius (at a large distance  from the waist) in radians.
+        I.e.  the angle between the optical axis and the beam radius (at a large distance  from the waist) in radians.
         """
-        return 2 * self.wavelength / (np.pi * self.w_0)
+        return self.wavelength / (np.pi * self.w_0)
 
     @property
     def param_str(self):

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -307,10 +307,9 @@ class FresnelWavefront(Wavefront):
     @property
     def divergence(self):
         """
-        Divergence of the gaussian beam
+        Full-angle divergence of the gaussian beam
 
-        I.e. the angle between the optical axis and the beam radius at a large distance.
-        Angle in radians.
+        I.e. twice the angle between the optical axis and the beam radius (at a large distance  from the waist) in radians.
         """
         return 2 * self.wavelength / (np.pi * self.w_0)
 


### PR DESCRIPTION
the returned divergence is the full angle not the half angle as previously implied. See definition in Kogelnik and Li, 1966, eq. 22, or the Newport Gaussian Beam Technical note (https://www.newport.com/n/gaussian-beam-optics)

Kogelnik, H., and T. Li. 1966. “Laser Beams and Resonators.” Applied Optics 5 (10): 1550–67. doi:10.1364/AO.5.001550.